### PR TITLE
Exactly once delivery with WAL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,12 @@
 
     <properties>
         <confluent.version>2.0-SNAPSHOT</confluent.version>
-        <copycat.version>2.0-SNAPSHOT</copycat.version>
+        <kafka.version>0.9.0.0-SNAPSHOT</kafka.version>
         <junit.version>4.11</junit.version>
-        <easymock.version>3.0</easymock.version>
-        <powermock.version>1.6.2</powermock.version>
-        <commons.version>2.4</commons.version>
         <hadoop.version>2.6.0</hadoop.version>
         <avro.version>1.7.7</avro.version>
         <parquet.version>1.7.0</parquet.version>
+        <commons-io.version>2.4</commons-io.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -49,19 +47,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.confluent</groupId>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>copycat-api</artifactId>
-            <version>${copycat.version}</version>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>copycat-runtime</artifactId>
-            <version>${copycat.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>copycat-data</artifactId>
-            <version>${copycat.version}</version>
+            <artifactId>copycat-avro-converter</artifactId>
+            <version>${confluent.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -72,30 +65,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,6 +92,11 @@
             <artifactId>parquet-avro</artifactId>
             <version>${parquet.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -139,7 +113,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.5.3</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/assembly/development.xml</descriptor>

--- a/src/main/java/io/confluent/copycat/hdfs/CommittedFileFilter.java
+++ b/src/main/java/io/confluent/copycat/hdfs/CommittedFileFilter.java
@@ -14,15 +14,20 @@
 
 package io.confluent.copycat.hdfs;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.kafka.copycat.sink.SinkRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 
-import java.io.IOException;
 
-import io.confluent.copycat.avro.AvroData;
+public class CommittedFileFilter implements PathFilter {
 
-public interface RecordWriterProvider {
+  @Override
+  public boolean accept(Path path) {
+    String filename = path.getName();
+    if (filename.equals("log") || filename.equals("log.1")) {
+      return false;
+    }
+    String[] parts = path.getName().split("_");
 
-  RecordWriter<Long, SinkRecord> getRecordWriter(Configuration conf, String fileName, SinkRecord record, AvroData avroData) throws
-                                                                                       IOException;
+    return !(parts.length != 2 || parts[1].equals("tmp"));
+  }
 }

--- a/src/main/java/io/confluent/copycat/hdfs/FSWAL.java
+++ b/src/main/java/io/confluent/copycat/hdfs/FSWAL.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.copycat.errors.CopycatException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import io.confluent.copycat.hdfs.WALFile.Reader;
+import io.confluent.copycat.hdfs.WALFile.Writer;
+
+public class FSWAL implements WAL {
+
+  private static final Logger log = LoggerFactory.getLogger(FSWAL.class);
+  private static final String leaseException =
+      "org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException";
+
+  private WALFile.Writer writer = null;
+  private WALFile.Reader reader = null;
+  private String logFile = null;
+  private Configuration conf = null;
+  private Storage storage;
+
+  public FSWAL(String topicsDir, TopicPartition topicPart, Storage storage)
+      throws CopycatException {
+
+    this.storage = storage;
+    this.conf = storage.conf();
+    String url = storage.url();
+    logFile = FileUtils.logFileName(url, topicsDir, topicPart);
+  }
+
+  @Override
+  public void append(String tempFile, String committedFile) throws CopycatException {
+    try {
+      acquireLease();
+      WALEntry key = new WALEntry(tempFile);
+      WALEntry value = new WALEntry(committedFile);
+      writer.append(key, value);
+      writer.hsync();
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  public void acquireLease() throws CopycatException {
+    long sleepIntervalMs = 1000L;
+    long MAX_SLEEP_INTERVAL_MS = 16000L;
+    while (sleepIntervalMs < MAX_SLEEP_INTERVAL_MS) {
+      try {
+        if (writer == null) {
+          writer = WALFile.createWriter(conf, Writer.file(new Path(logFile)),
+                                        Writer.appendIfExists(true));
+        }
+        log.info("Successfully acquired lease for {}", logFile);
+        break;
+      } catch (RemoteException e) {
+        if (e.getClassName().equals(leaseException)) {
+          log.info("Cannot acquire lease on FSWAL {}", logFile);
+          try {
+            Thread.sleep(sleepIntervalMs);
+          } catch (InterruptedException ie) {
+            throw new CopycatException(ie);
+          }
+          sleepIntervalMs = sleepIntervalMs * 2;
+        } else {
+          throw new CopycatException(e);
+        }
+      } catch (IOException e) {
+        throw new CopycatException("Error creating writer for log file " + logFile, e);
+      }
+    }
+    if (sleepIntervalMs >= MAX_SLEEP_INTERVAL_MS) {
+      throw new CopycatException("Cannot acquire lease after timeout, will retry.");
+    }
+  }
+
+  @Override
+  public void apply() throws CopycatException {
+    try {
+      if (!storage.exists(logFile)) {
+        return;
+      }
+      acquireLease();
+      if (reader == null) {
+        reader = new WALFile.Reader(conf, Reader.file(new Path(logFile)));
+      }
+      WALEntry key = new WALEntry();
+      WALEntry value = new WALEntry();
+      while (reader.next(key, value)) {
+        String tempFile = key.getFilename();
+        String committedFile = value.getFilename();
+        if (!storage.exists(committedFile)) {
+          storage.commit(tempFile, committedFile);
+        }
+      }
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  @Override
+  public void truncate() throws CopycatException {
+    try {
+      String oldLogFile = logFile + ".1";
+      storage.delete(oldLogFile);
+      storage.commit(logFile, oldLogFile);
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  @Override
+  public void close() throws CopycatException {
+    try {
+      if (writer != null) {
+        writer.hsync();
+        writer.close();
+      }
+      if (reader != null) {
+        reader.close();
+      }
+    } catch (IOException e) {
+      throw new CopycatException("Error closing " + logFile, e);
+    }
+  }
+
+  @Override
+  public String getLogFile() {
+    return logFile;
+  }
+}

--- a/src/main/java/io/confluent/copycat/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/copycat/hdfs/FileUtils.java
@@ -18,10 +18,10 @@ package io.confluent.copycat.hdfs;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.TopicPartition;
 
 import java.io.IOException;
-
-import io.confluent.copycat.connector.TopicPartition;
+import java.util.UUID;
 
 public class FileUtils {
 
@@ -38,19 +38,31 @@ public class FileUtils {
   }
 
   public static String tempFileName(String url, String topicsDir, TopicPartition topicPart) {
-    return fileName(url, topicsDir, topicPart, "tmp");
+    UUID id = UUID.randomUUID();
+    String name = id.toString() + "_" + "tmp";
+    return fileName(url, topicsDir, topicPart, name);
   }
 
   public static String committedFileName(String url, String topicsDir, TopicPartition topicPart,
-                                         long offset) {
-    String suffix = String.valueOf(offset);
-    return fileName(url, topicsDir, topicPart, suffix);
+                                         long startOffset, long endOffset) {
+    String name = String.valueOf(startOffset) + "_" + String.valueOf(endOffset);
+    return fileName(url, topicsDir, topicPart, name);
   }
 
-  public static String fileName(String url, String topicsDir, TopicPartition topicPart, String suffix) {
+  public static String logFileName(String url, String topicsDir, TopicPartition topicPart) {
+    return fileName(url, topicsDir, topicPart, "log");
+  }
+
+  public static String directoryName(String url, String topicsDir, TopicPartition topicPart) {
     String topic = topicPart.topic();
     int partition = topicPart.partition();
-    return url + "/" + topicsDir + "/" + topic + "/" + partition + "." + suffix;
+    return url + "/" + topicsDir + "/" + topic + "/" + partition;
+  }
+
+  public static String fileName(String url, String topicsDir, TopicPartition topicPart, String name) {
+    String topic = topicPart.topic();
+    int partition = topicPart.partition();
+    return url + "/" + topicsDir + "/" + topic + "/" + partition + "/" + name;
   }
 
 }

--- a/src/main/java/io/confluent/copycat/hdfs/HdfsSinkConnector.java
+++ b/src/main/java/io/confluent/copycat/hdfs/HdfsSinkConnector.java
@@ -14,15 +14,16 @@
 
 package io.confluent.copycat.hdfs;
 
+
+import org.apache.kafka.copycat.connector.Connector;
+import org.apache.kafka.copycat.connector.Task;
+import org.apache.kafka.copycat.errors.CopycatException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
 import io.confluent.common.config.ConfigException;
-import io.confluent.copycat.connector.Connector;
-import io.confluent.copycat.connector.Task;
-import io.confluent.copycat.errors.CopycatException;
-import io.confluent.copycat.errors.CopycatRuntimeException;
 
 /**
  * HdfsSinkConnector is a Copycat Connector implementation that ingest data
@@ -39,19 +40,19 @@ public class HdfsSinkConnector extends Connector{
       configProperties = props;
       config = new HdfsSinkConnectorConfig(props);
     } catch (ConfigException e) {
-      throw new CopycatRuntimeException("Couldn't start HdfsSinkConnector due to configuration "
+      throw new CopycatException("Couldn't start HdfsSinkConnector due to configuration "
                                          + "error", e);
     }
   }
 
   @Override
-  public Class<? extends Task> getTaskClass() {
+  public Class<? extends Task> taskClass() {
     return HdfsSinkTask.class;
   }
 
   @Override
-  public List<Properties> getTaskConfigs(int maxTasks) {
-    List<Properties> taskConfigs = new ArrayList<Properties>();
+  public List<Properties> taskConfigs(int maxTasks) {
+    List<Properties> taskConfigs = new ArrayList<>();
     Properties taskProps = new Properties();
     taskProps.putAll(configProperties);
     for (int i = 0; i < maxTasks; i++) {

--- a/src/main/java/io/confluent/copycat/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/copycat/hdfs/HdfsSinkConnectorConfig.java
@@ -1,17 +1,15 @@
 /**
  * Copyright 2015 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  **/
 
 package io.confluent.copycat.hdfs;
@@ -24,21 +22,38 @@ import io.confluent.common.config.ConfigDef.Type;
 import io.confluent.common.config.ConfigDef.Importance;
 
 public class HdfsSinkConnectorConfig extends AbstractConfig {
+
   public static final String HDFS_URL_CONFIG = "hdfs.url";
   private static final String HDFS_URL_DOC = "HDFS connection URL.";
   public static final String RECORD_WRITER_PROVIDER_CLASS_CONFIG = "record.writer.provider.class";
   private static final String RECORD_WRITER_PROVIDER_CLASS_DOC = "";
   public static final String FLUSH_SIZE_CONFIG = "flush.size";
   private static final String FLUSH_SIZE_DOC = "The number of records needed to rotate files.";
+  public static final String ROTATE_INTERVAL_CONFIG = "rotate.interval.ms";
+  private static final String ROTATE_INTERVAL_DOC = "The interval to rotate files.";
   public static final String TOPIC_DIR_CONFIG = "topic.dir";
-  private static final String TOPIC_DIR_DOC = "HDFS directory to store data";
+  private static final String TOPIC_DIR_DOC = "HDFS directory to store data.";
   public static final String TOPIC_DIR_DEFAULT = "topics";
+  public static final String SCHEMA_CACHE_SIZE_CONFIG = "schema.cache.size";
+  public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
+  private static final String SCHEMA_CACHE_SIZE_DOC = "The size of the schema cache.";
+  public static final String STORAGE_CLASS_CONFIG = "storage.class";
+  private static final String STORAGE_CLASS_DOC = "The storage layer.";
+  public static final String STORAGE_CLASS_DEFAULT = "io.confluent.copycat.hdfs.HdfsStorage";
+  public static final String RETRY_BACKOFF_CONFIG = "retry.backoff.ms";
+  private static final String RETRY_BACKOFF_DOC = "The retry backoff in milliseconds.";
+  public static final long RETRY_BACKOFF_DEFALUT = 5000L;
 
   static ConfigDef config = new ConfigDef()
       .define(HDFS_URL_CONFIG, Type.STRING, Importance.HIGH, HDFS_URL_DOC)
-      .define(RECORD_WRITER_PROVIDER_CLASS_CONFIG, Type.STRING, Importance.HIGH, RECORD_WRITER_PROVIDER_CLASS_DOC)
+      .define(RECORD_WRITER_PROVIDER_CLASS_CONFIG, Type.STRING, Importance.HIGH,
+              RECORD_WRITER_PROVIDER_CLASS_DOC)
       .define(FLUSH_SIZE_CONFIG, Type.INT, Importance.HIGH, FLUSH_SIZE_DOC)
-      .define(TOPIC_DIR_CONFIG, Type.STRING, TOPIC_DIR_DEFAULT, Importance.HIGH, TOPIC_DIR_DOC);
+      .define(ROTATE_INTERVAL_CONFIG, Type.INT, Importance.HIGH, ROTATE_INTERVAL_DOC)
+      .define(TOPIC_DIR_CONFIG, Type.STRING, TOPIC_DIR_DEFAULT, Importance.HIGH, TOPIC_DIR_DOC)
+      .define(SCHEMA_CACHE_SIZE_CONFIG, Type.INT, SCHEMA_CACHE_SIZE_DEFAULT, Importance.MEDIUM, SCHEMA_CACHE_SIZE_DOC)
+      .define(STORAGE_CLASS_CONFIG, Type.STRING, STORAGE_CLASS_DEFAULT, Importance.MEDIUM, STORAGE_CLASS_DOC)
+      .define(RETRY_BACKOFF_CONFIG, Type.LONG, RETRY_BACKOFF_DEFALUT, Importance.HIGH, RETRY_BACKOFF_DOC);
 
   HdfsSinkConnectorConfig(Properties props) {
     super(config, props);

--- a/src/main/java/io/confluent/copycat/hdfs/HdfsSinkTask.java
+++ b/src/main/java/io/confluent/copycat/hdfs/HdfsSinkTask.java
@@ -1,21 +1,24 @@
 /**
  * Copyright 2015 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  **/
 
 package io.confluent.copycat.hdfs;
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.copycat.errors.CopycatException;
+import org.apache.kafka.copycat.sink.SinkRecord;
+import org.apache.kafka.copycat.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,17 +26,16 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import io.confluent.common.config.ConfigException;
-import io.confluent.copycat.connector.TopicPartition;
-import io.confluent.copycat.errors.CopycatException;
-import io.confluent.copycat.errors.CopycatRuntimeException;
-import io.confluent.copycat.sink.SinkRecord;
-import io.confluent.copycat.sink.SinkTask;
+import io.confluent.copycat.avro.AvroData;
 
 public class HdfsSinkTask extends SinkTask {
+
   private static final Logger log = LoggerFactory.getLogger(HdfsSinkTask.class);
   private HdfsWriter hdfsWriter;
+  private AvroData avroData;
 
   public HdfsSinkTask() {
 
@@ -43,37 +45,56 @@ public class HdfsSinkTask extends SinkTask {
   public void start(Properties props) {
     try {
       HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
-      hdfsWriter = new HdfsWriter(connectorConfig);
-      context.resetOffset(hdfsWriter.getPreviousOffsets());
+      int schemaCacheSize = connectorConfig.getInt(HdfsSinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG);
+      avroData = new AvroData(schemaCacheSize);
+      hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+      Set<TopicPartition> assignment = context.assignment();
+      recover(assignment);
     } catch (ConfigException e) {
-      throw new CopycatRuntimeException(
+      throw new CopycatException(
           "Couldn't start HdfsSinkConnector due to configuration error.", e);
+    } catch (CopycatException e) {
+      hdfsWriter.close();
     }
   }
 
   @Override
   public void stop() throws CopycatException {
-    try {
-      hdfsWriter.close();
-    } catch (IOException e) {
-      throw new CopycatRuntimeException("Error closing the HDFS writer", e);
-    }
+    hdfsWriter.close();
+
   }
 
   @Override
   public void put(Collection<SinkRecord> records) throws CopycatException {
-    String topic;
-    int partition;
-    for (SinkRecord record: records) {
-      topic = record.getTopic();
-      partition = record.getPartition();
-      TopicPartition topicPart = new TopicPartition(topic, partition);
-      hdfsWriter.writeRecord(topicPart, record);
+    try {
+      hdfsWriter.write(records);
+    } catch (IOException e) {
+      throw new CopycatException(e);
     }
   }
 
   @Override
-  public void flush(Map<TopicPartition, Long> offsets) {
-    // Do nothing as we manage the offset
+  public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    // Do nothing as the connector manages the offset
+  }
+
+  @Override
+  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    hdfsWriter.onPartitionsAssigned(partitions);
+  }
+
+  @Override
+  public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+    hdfsWriter.onPartitionsRevoked(partitions);
+  }
+
+  private void recover(Set<TopicPartition> assignment) {
+    for (TopicPartition tp: assignment) {
+      hdfsWriter.recover(tp);
+    }
+  }
+
+  public AvroData getAvroData() {
+    return avroData;
   }
 }

--- a/src/main/java/io/confluent/copycat/hdfs/HdfsStorage.java
+++ b/src/main/java/io/confluent/copycat/hdfs/HdfsStorage.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class HdfsStorage implements Storage {
+
+  private final FileSystem fs;
+  private final Configuration conf;
+  private final String url;
+
+  public HdfsStorage(Configuration conf,  String url) throws IOException {
+    fs = FileSystem.newInstance(URI.create(url), conf);
+    this.conf = conf;
+    this.url = url;
+  }
+
+  @Override
+  public FileStatus[] listStatus(String path, PathFilter filter) throws IOException {
+    return fs.listStatus(new Path(path), filter);
+  }
+  
+  @Override
+  public void append(String filename, Object object) throws IOException {
+
+  }
+
+  @Override
+  public boolean mkdirs(String filename) throws IOException {
+    return fs.mkdirs(new Path(filename));
+  }
+
+  @Override
+  public boolean exists(String filename) throws IOException {
+    return fs.exists(new Path(filename));
+  }
+
+  @Override
+  public void commit(String tempFile, String committedFile) throws IOException {
+    FileUtils.renameFile(fs, tempFile, committedFile);
+  }
+
+  @Override
+  public void delete(String filename) throws IOException {
+    fs.delete(new Path(filename), true);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (fs != null) {
+      fs.close();
+    }
+  }
+
+  @Override
+  public WAL wal(String topicsDir, TopicPartition topicPart) {
+    return new FSWAL(topicsDir, topicPart, this);
+  }
+
+  @Override
+  public Configuration conf() {
+    return conf;
+  }
+
+  @Override
+  public String url() {
+    return url;
+  }
+}

--- a/src/main/java/io/confluent/copycat/hdfs/HdfsWriter.java
+++ b/src/main/java/io/confluent/copycat/hdfs/HdfsWriter.java
@@ -1,167 +1,362 @@
 /**
  * Copyright 2015 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  **/
 
 package io.confluent.copycat.hdfs;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.copycat.errors.CopycatException;
+import org.apache.kafka.copycat.errors.IllegalWorkerStateException;
+import org.apache.kafka.copycat.sink.SinkRecord;
+import org.apache.kafka.copycat.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 
-import io.confluent.copycat.connector.TopicPartition;
-import io.confluent.copycat.errors.CopycatException;
-import io.confluent.copycat.errors.CopycatRuntimeException;
-import io.confluent.copycat.sink.SinkRecord;
-
+import io.confluent.copycat.avro.AvroData;
 
 public class HdfsWriter {
+
   private static final Logger log = LoggerFactory.getLogger(HdfsWriter.class);
   private Map<TopicPartition, RecordWriter<Long, SinkRecord>> writers = null;
+  private Map<TopicPartition, WAL> wals = null;
+  private Map<TopicPartition, String> tempFileNames = null;
   private Map<TopicPartition, Long> offsets = null;
   private Map<TopicPartition, Integer> recordCounters = null;
   private Configuration conf;
-  private FileSystem fs;
-  private Class<? extends RecordWriterProvider> writerProviderClass;
+  private RecordWriterProvider writerProvider;
   private String url;
   private int flushSize;
   private String topicsDir;
+  private Set<TopicPartition> assignment;
+  private AvroData avroData;
+  private SinkTaskContext context;
+  private Map<TopicPartition, State> states;
+  private Set<TopicPartition> recovered;
+  private Map<TopicPartition, Queue<SinkRecord>> buffer;
+  private Storage storage;
+  private long backOffMs;
+  private Set<TopicPartition> lastAssignment;
+  private Map<TopicPartition, Long> failureTime;
+
+  private enum State {
+    RECOVERY_STARTED,
+    RECOVERY_PARTITION_PAUSED,
+    WAL_CREATED,
+    WAL_APPLIED,
+    WAL_TRUNCATED,
+    OFFSET_RESET,
+    WRITE_STARTED,
+    WRITE_PARTITION_PAUSED,
+    SHOULD_ROTATE,
+    TEMP_FILE_CLOSED,
+    WAL_APPENDED,
+    FILE_COMMITTED;
+
+    private static State[] vals = values();
+    public State next() {
+      return vals[(this.ordinal() + 1) % vals.length];
+    }
+  }
+
 
   @SuppressWarnings("unchecked")
-  public HdfsWriter(HdfsSinkConnectorConfig connectorConfig) {
+  public HdfsWriter(HdfsSinkConnectorConfig connectorConfig, SinkTaskContext context, AvroData avroData) {
     try {
-      writers = new HashMap<TopicPartition, RecordWriter<Long, SinkRecord>>();
-      recordCounters = new HashMap<TopicPartition, Integer>();
-      flushSize = connectorConfig.getInt(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG);
+      writers = new HashMap<>();
+      wals = new HashMap<>();
+      offsets = new HashMap<>();
+      recordCounters = new HashMap<>();
+      tempFileNames = new HashMap<>();
 
+      flushSize = connectorConfig.getInt(HdfsSinkConnectorConfig.FLUSH_SIZE_CONFIG);
+      backOffMs = connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG);
       url = connectorConfig.getString(HdfsSinkConnectorConfig.HDFS_URL_CONFIG);
       topicsDir = connectorConfig.getString(HdfsSinkConnectorConfig.TOPIC_DIR_CONFIG);
       conf = new Configuration();
-      fs = FileSystem.newInstance(URI.create(url), conf);
-      Path path = new Path(url + "/" + topicsDir);
-      if (!fs.exists(path)) {
-        fs.mkdirs(path);
+
+      Class<? extends Storage> storageClass =
+          (Class<? extends Storage>) Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
+      this.storage = StorageFactory.createStorage(storageClass, conf, url);
+      createTopicsDir();
+      writerProvider = ((Class<RecordWriterProvider>) Class.forName(connectorConfig.getString(
+              HdfsSinkConnectorConfig.RECORD_WRITER_PROVIDER_CLASS_CONFIG))).newInstance();
+
+      this.context = context;
+      this.assignment = context.assignment();
+      this.avroData = avroData;
+
+      states = new HashMap<>();
+      for (TopicPartition tp: assignment) {
+        states.put(tp, State.RECOVERY_STARTED);
       }
-      offsets = readOffsets();
-      writerProviderClass = (Class<RecordWriterProvider>)
-          Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.RECORD_WRITER_PROVIDER_CLASS_CONFIG));
+      buffer = new HashMap<>();
+      for (TopicPartition tp: assignment) {
+        buffer.put(tp, new LinkedList<SinkRecord>());
+      }
+      recovered = new HashSet<>();
+      lastAssignment = new HashSet<>();
+      failureTime = new HashMap<>();
     } catch (IOException e) {
-      throw new CopycatRuntimeException(e);
-    } catch (ClassNotFoundException e) {
-      throw new CopycatRuntimeException("RecordWriterProvider class not found", e);
+      throw new CopycatException(e);
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+      throw new CopycatException("Reflection exception: ", e);
     }
   }
 
-
-  public Map<TopicPartition, Long> getPreviousOffsets() {
+  /**
+   * @return get committed offsets of previous task runs.
+   */
+  public Map<TopicPartition, Long> getCommittedOffsets() {
     return offsets;
   }
 
-  public void writeRecord(TopicPartition topicPart, SinkRecord record)
-      throws CopycatException{
+  public void write(Collection<SinkRecord> records) throws IOException {
+    String topic;
+    int partition;
+    for (SinkRecord record: records) {
+      topic = record.topic();
+      partition = record.kafkaPartition();
+      TopicPartition topicPart = new TopicPartition(topic, partition);
+      buffer.get(topicPart).add(record);
+    }
+    for (TopicPartition topicPart: assignment) {
+      if (failureTime.containsKey(topicPart)) {
+        long now = System.currentTimeMillis();
+        if (now - failureTime.get(topicPart) < backOffMs) {
+          continue;
+        }
+        failureTime.remove(topicPart);
+      }
+      execute(topicPart);
+    }
+  }
+
+  public void recover(TopicPartition topicPart) {
     try {
-      RecordWriter<Long, SinkRecord> writer = getWriter(topicPart, record);
-      writer.write(System.currentTimeMillis(), record);
-      if (!offsets.containsKey(topicPart)) {
-        offsets.put(topicPart, record.getOffset() - 1);
+      switch (states.get(topicPart)) {
+        case RECOVERY_STARTED:
+          pause(topicPart);
+          nextState(topicPart);
+        case RECOVERY_PARTITION_PAUSED:
+          createWAL(topicPart);
+          nextState(topicPart);
+        case WAL_CREATED:
+          applyWAL(topicPart);
+          nextState(topicPart);
+        case WAL_APPLIED:
+          truncateWAL(topicPart);
+          nextState(topicPart);
+        case WAL_TRUNCATED:
+          resetOffsets(topicPart);
+          nextState(topicPart);
+        case OFFSET_RESET:
+          resume(topicPart);
+          nextState(topicPart);
+          break;
+        default:
+          log.error("{} is not a valid state to perform recovery.", states.get(topicPart));
       }
-      updateRecordCounter(topicPart);
-      if (shouldRotate(topicPart)) {
-        rotate(topicPart);
-      }
-    } catch (IOException e) {
-      throw new CopycatRuntimeException(e);
+    } catch (CopycatException e) {
+      log.error("Recovery failed.");
+      recordFailureTime(topicPart);
+      setRetryBackoff(backOffMs);
     }
   }
 
-  public void close() throws IOException, CopycatException {
-    for (TopicPartition topicPart: writers.keySet()) {
-      rotate(topicPart);
+  private void execute(TopicPartition topicPart) throws IOException {
+    Queue<SinkRecord> records = buffer.get(topicPart);
+    if (states.get(topicPart).compareTo(State.WRITE_STARTED) < 0) {
+      recover(topicPart);
     }
-    writers.clear();
-    if (fs != null) {
-      fs.close();
-    }
-  }
-
-  private Map<TopicPartition, Long> readOffsets() throws IOException {
-    Map<TopicPartition, Long> offsets = new HashMap<TopicPartition, Long>();
-    Path path = new Path(url + "/" + topicsDir);
-    PathFilter filter = new CommittedFileFilter();
-    FileStatus[] topics = fs.listStatus(path);
-    for (FileStatus topic: topics) {
-      if (topic.isDirectory()) {
-        String topicName = topic.getPath().getName();
-        FileStatus[] partitions = fs.listStatus(topic.getPath(), filter);
-        for (FileStatus partition : partitions) {
-          if (partition.isFile()) {
-            String filename = partition.getPath().getName();
-            String[] parts = filename.split("\\.");
-            try {
-              int partitionNum = Integer.parseInt(parts[0]);
-              long offset = Long.parseLong(parts[1]);
-              TopicPartition topicPart = new TopicPartition(topicName, partitionNum);
-              if (!offsets.containsKey(topicPart) || offset > offsets.get(topicPart)) {
-                offsets.put(topicPart, offset);
-              }
-            } catch (NumberFormatException e) {
-              log.warn("Invalid Copycat HDFS file: {}", filename);
+    while(!records.isEmpty()) {
+      try {
+        switch (states.get(topicPart)) {
+          case WRITE_STARTED:
+            pause(topicPart);
+            nextState(topicPart);
+          case WRITE_PARTITION_PAUSED:
+            writeRecord(topicPart, records.peek());
+            records.poll();
+            if (shouldRotate(topicPart)) {
+              nextState(topicPart);
+            } else {
+              break;
             }
+          case SHOULD_ROTATE:
+            closeTempfile(topicPart);
+            nextState(topicPart);
+          case TEMP_FILE_CLOSED:
+            appendToWAL(topicPart);
+            nextState(topicPart);
+          case WAL_APPENDED:
+            commitFile(topicPart);
+            nextState(topicPart);
+          case FILE_COMMITTED:
+            setState(topicPart, State.WRITE_PARTITION_PAUSED);
+            break;
+          default:
+            log.error("{} is not a valid state to write record.", states.get(topicPart));
+        }
+      } catch (IllegalWorkerStateException e) {
+        // Should we retry in this case?
+        throw e;
+      } catch (IOException | CopycatException e) {
+        log.error("Exception on {}", topicPart);
+        recordFailureTime(topicPart);
+        setRetryBackoff(backOffMs);
+        break;
+      }
+    }
+    if (records.isEmpty()) {
+      resume(topicPart);
+      setState(topicPart, State.WRITE_STARTED);
+    }
+  }
+
+  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    assignment.clear();
+    assignment.addAll(partitions);
+
+    // handle partitions that no longer assigned to the task
+    for (TopicPartition topicPart: lastAssignment) {
+      if (!assignment.contains(topicPart)) {
+        try {
+          if (writers.containsKey(topicPart)) {
+            closeTempfile(topicPart);
+            appendToWAL(topicPart);
+            commitFile(topicPart);
           }
+        } catch (IOException e) {
+          log.error("Error rotating {} when closing task.", tempFileNames.get(topicPart));
+          if (writers.containsKey(topicPart)) {
+            writers.remove(topicPart);
+          }
+        }
+
+        WAL wal = null;
+        try {
+          if (wals.containsKey(topicPart)) {
+            wal = wals.get(topicPart);
+            wal.close();
+            wals.remove(topicPart);
+          }
+        } catch (CopycatException e) {
+          log.error("Error closing {}.", wal.getLogFile());
+          if (wals.containsKey(topicPart)){
+            wals.remove(topicPart);
+          }
+        }
+
+        buffer.remove(topicPart);
+        states.remove(topicPart);
+        tempFileNames.remove(topicPart);
+        offsets.remove(topicPart);
+        recordCounters.remove(topicPart);
+        failureTime.remove(topicPart);
+        if (recovered.contains(topicPart)) {
+          recovered.remove(topicPart);
         }
       }
     }
-    return offsets;
-  }
 
-  private class CommittedFileFilter implements PathFilter {
-    public boolean accept(Path path) {
-      String[] parts = path.getName().split("\\.");
-      return !(parts.length != 2 || parts[1].equals("tmp"));
+    // handle new partitions
+    for (TopicPartition topicPart: assignment) {
+      if (!lastAssignment.contains(topicPart)) {
+        states.put(topicPart, State.RECOVERY_STARTED);
+        buffer.put(topicPart, new LinkedList<SinkRecord>());
+      }
     }
   }
 
-  private RecordWriter<Long, SinkRecord> getWriter(TopicPartition topicPart, SinkRecord record)
+  public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+    lastAssignment.clear();
+    lastAssignment.addAll(partitions);
+  }
+
+  private void nextState(TopicPartition topicPart) {
+    State curState = states.get(topicPart);
+    states.put(topicPart, curState.next());
+  }
+
+  private void setState(TopicPartition topicPart, State state) {
+    states.put(topicPart, state);
+  }
+
+  private void recordFailureTime(TopicPartition topicPart) {
+    long time = System.currentTimeMillis();
+    failureTime.put(topicPart, time);
+  }
+
+  private void createTopicsDir() throws IOException {
+    String dir = url + "/" + topicsDir;
+    if (!storage.exists(dir)) {
+      storage.mkdirs(dir);
+    }
+  }
+
+  private void readOffsets(TopicPartition topicPart) throws CopycatException {
+    String path = FileUtils.directoryName(url, topicsDir, topicPart);
+    PathFilter filter = new CommittedFileFilter();
+    try {
+      if (!storage.exists(path)) {
+        return;
+      }
+      FileStatus[] committedFiles = storage.listStatus(path, filter);
+      for (FileStatus committedFile : committedFiles) {
+        String filename = committedFile.getPath().getName();
+        String[] parts = filename.split("_");
+        try {
+          long endOffset = Long.parseLong(parts[1]);
+          if (!offsets.containsKey(topicPart) || endOffset > offsets.get(topicPart)) {
+            offsets.put(topicPart, endOffset);
+          }
+        } catch (NumberFormatException e) {
+          log.warn("Invalid committed file: {}", filename);
+        }
+      }
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  public RecordWriter<Long, SinkRecord> getWriter(TopicPartition topicPart, SinkRecord record)
       throws CopycatException {
     try {
-      if (writers.containsKey(topicPart)) return writers.get(topicPart);
-      String fileName = FileUtils.tempFileName(url, topicsDir, topicPart);
-      Path path = new Path(fileName);
-      if (fs.exists(path)) {
-        log.info("Deleting uncommited file {}", fileName);
-        fs.delete(path, false);
+      if (writers.containsKey(topicPart)) {
+        return writers.get(topicPart);
       }
-      RecordWriter<Long, SinkRecord> writer = writerProviderClass.newInstance().
-          getRecordWriter(conf, fileName, record);
+      String fileName = FileUtils.tempFileName(url, topicsDir, topicPart);
+      RecordWriter<Long, SinkRecord> writer = writerProvider.getRecordWriter(conf, fileName, record, avroData);
       writers.put(topicPart, writer);
+      tempFileNames.put(topicPart, fileName);
       recordCounters.put(topicPart, 0);
       return writer;
-    } catch (IllegalAccessException e) {
-      throw new CopycatRuntimeException(e);
-    } catch (InstantiationException e) {
-      throw new CopycatRuntimeException(e);
     } catch (IOException e) {
-      throw new CopycatRuntimeException(e);
+      throw new CopycatException(e);
     }
   }
 
@@ -169,25 +364,53 @@ public class HdfsWriter {
     return recordCounters.containsKey(topicPart) && recordCounters.get(topicPart) >= flushSize;
   }
 
-  private void rotate(TopicPartition topicPart)
-      throws CopycatException {
-    try {
-      RecordWriter<Long, SinkRecord> writer = writers.get(topicPart);
-      writer.close();
-      writers.remove(topicPart);
-      commitFile(topicPart);
-    } catch (IOException e) {
-      throw new CopycatRuntimeException(e);
+  public void close() throws CopycatException {
+    List<Exception> exceptions = new ArrayList<>();
+    for (TopicPartition topicPart : assignment) {
+      try {
+        if (writers.containsKey(topicPart)) {
+          closeTempfile(topicPart);
+          appendToWAL(topicPart);
+          commitFile(topicPart);
+        }
+      } catch (IOException e) {
+        log.error("Error rotating {} when closing task.", tempFileNames.get(topicPart));
+        exceptions.add(e);
+      }
     }
-  }
+    writers.clear();
 
-  private void commitFile(TopicPartition topicPart) throws IOException {
-    long offset;
-    offset = offsets.get(topicPart) + recordCounters.get(topicPart);
-    offsets.put(topicPart, offset);
-    String tempFileName = FileUtils.tempFileName(url, topicsDir, topicPart);
-    String finalFileName = FileUtils.committedFileName(url, topicsDir, topicPart, offset);
-    FileUtils.renameFile(fs, tempFileName, finalFileName);
+    for (WAL wal : wals.values()) {
+      try {
+        wal.close();
+      } catch (CopycatException e) {
+        log.error("Error closing {}.", wal.getLogFile());
+        exceptions.add(e);
+      }
+    }
+    wals.clear();
+
+    tempFileNames.clear();
+    recordCounters.clear();
+    offsets.clear();
+    lastAssignment.clear();
+    failureTime.clear();
+
+    try {
+      storage.close();
+    } catch (IOException e) {
+      log.error("Error closing storage {}.", storage.url());
+      exceptions.add(e);
+    }
+
+    if (exceptions.size() != 0) {
+      StringBuilder sb = new StringBuilder();
+      for (Exception exception: exceptions) {
+        sb.append(exception.getMessage());
+        sb.append("\n");
+      }
+      throw new CopycatException("Error closing writer: " + sb.toString());
+    }
   }
 
   private void updateRecordCounter(TopicPartition topicPart) {
@@ -198,5 +421,102 @@ public class HdfsWriter {
       count++;
       recordCounters.put(topicPart, count);
     }
+  }
+
+  private void pause(TopicPartition topicPart) {
+    context.pause(topicPart);
+  }
+
+  private void resume(TopicPartition topicPart) {
+    context.resume(topicPart);
+  }
+
+  private void createWAL(TopicPartition topicPart) throws CopycatException {
+    if (!wals.containsKey(topicPart)) {
+      WAL wal = storage.wal(topicsDir, topicPart);
+      wals.put(topicPart, wal);
+    }
+  }
+
+  private void applyWAL(TopicPartition topicPart) throws CopycatException {
+    if (!recovered.contains(topicPart)) {
+      WAL wal = wals.get(topicPart);
+      wal.apply();
+    }
+  }
+
+  private void truncateWAL(TopicPartition topicPart) throws CopycatException {
+    if (!recovered.contains(topicPart)) {
+      WAL wal = wals.get(topicPart);
+      wal.truncate();
+    }
+  }
+
+  private void resetOffsets(TopicPartition topicPart) throws CopycatException {
+    if (!recovered.contains(topicPart)) {
+      readOffsets(topicPart);
+      if (offsets.containsKey(topicPart)) {
+        long offset = offsets.get(topicPart);
+        context.offset(topicPart, offset);
+      }
+      recovered.add(topicPart);
+    }
+  }
+
+  private void writeRecord(TopicPartition topicPart, SinkRecord record) throws IOException {
+    RecordWriter<Long, SinkRecord> writer = getWriter(topicPart, record);
+    writer.write(System.currentTimeMillis(), record);
+    if (!offsets.containsKey(topicPart)) {
+      offsets.put(topicPart, record.kafkaOffset() - 1);
+    }
+    updateRecordCounter(topicPart);
+  }
+
+  private void closeTempfile(TopicPartition topicPart) throws IOException {
+    if (writers.containsKey(topicPart)) {
+      RecordWriter writer = writers.get(topicPart);
+      writer.close();
+      writers.remove(topicPart);
+    }
+  }
+
+  private void appendToWAL(TopicPartition topicPart) throws IOException {
+    long startOffset = offsets.get(topicPart) + 1;
+    long endOffset = startOffset + recordCounters.get(topicPart) - 1;
+    String tempFileName = tempFileNames.get(topicPart);
+    String finalFileName = FileUtils.committedFileName(url, topicsDir, topicPart, startOffset, endOffset);
+    WAL wal = wals.get(topicPart);
+    wal.append(tempFileName, finalFileName);
+  }
+
+  private void commitFile(TopicPartition topicPart) throws IOException {
+    long startOffset = offsets.get(topicPart) + 1;
+    long endOffset = startOffset + recordCounters.get(topicPart) - 1;
+    String tempFileName = tempFileNames.get(topicPart);
+    String finalFileName =
+        FileUtils.committedFileName(url, topicsDir, topicPart, startOffset, endOffset);
+    storage.commit(tempFileName, finalFileName);
+    offsets.put(topicPart, endOffset);
+  }
+
+  private void setRetryBackoff(long backOffMs) {
+    context.timeout(backOffMs);
+  }
+
+
+  public Storage getStorage() {
+    return storage;
+  }
+
+  public String getTempFileNames(TopicPartition topicPart) {
+    return tempFileNames.get(topicPart);
+  }
+
+  public RecordWriter getRecordWriter(TopicPartition topicPart) {
+    return writers.get(topicPart);
+  }
+
+  public WAL getWAL(TopicPartition topicPart) {
+    return wals.get(topicPart);
   }
 }

--- a/src/main/java/io/confluent/copycat/hdfs/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/copycat/hdfs/ParquetRecordWriterProvider.java
@@ -1,17 +1,15 @@
 /**
  * Copyright 2015 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  **/
 package io.confluent.copycat.hdfs;
 
@@ -19,23 +17,22 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.copycat.sink.SinkRecord;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.io.IOException;
 
-import io.confluent.copycat.sink.SinkRecord;
-import io.confluent.copycat.util.AvroData;
+import io.confluent.copycat.avro.AvroData;
 
 public class ParquetRecordWriterProvider implements RecordWriterProvider {
 
   @Override
-  public RecordWriter<Long, SinkRecord> getRecordWriter(Configuration conf, String fileName, SinkRecord record)
-      throws IOException{
-    Object value = AvroData.convertToAvro(record.getValue());
-    Schema avroSchema = ((GenericRecord) value).getSchema();
-
+  public RecordWriter<Long, SinkRecord> getRecordWriter(Configuration conf, final String fileName,
+                                                        SinkRecord record, final AvroData avroData)
+      throws IOException {
+    final Schema avroSchema = avroData.fromCopycatSchema(record.valueSchema());
     CompressionCodecName compressionCodecName = CompressionCodecName.SNAPPY;
 
     int blockSize = 256 * 1024 * 1024;
@@ -44,17 +41,17 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider {
     Path path = new Path(fileName);
     path.getFileSystem(conf).create(path);
     final ParquetWriter<GenericRecord> writer =
-        new AvroParquetWriter<GenericRecord>(path, avroSchema, compressionCodecName, blockSize, pageSize);
+        new AvroParquetWriter<>(path, avroSchema, compressionCodecName, blockSize, pageSize);
 
-    return new RecordWriter<Long, SinkRecord>(){
+    return new RecordWriter<Long, SinkRecord>() {
       @Override
-      public void write(Long key, SinkRecord record) throws IOException{
-        Object value = AvroData.convertToAvro(record.getValue());
+      public void write(Long key, SinkRecord record) throws IOException {
+        Object value = avroData.fromCopycatData(record.valueSchema(), record.value());
         writer.write((GenericRecord) value);
       }
 
       @Override
-      public void close() throws IOException{
+      public void close() throws IOException {
         writer.close();
       }
     };

--- a/src/main/java/io/confluent/copycat/hdfs/Storage.java
+++ b/src/main/java/io/confluent/copycat/hdfs/Storage.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.IOException;
+
+public interface Storage {
+  boolean exists(String filename) throws IOException;
+  boolean mkdirs(String filename) throws IOException;
+  void append(String filename, Object object) throws IOException;
+  void delete(String filename) throws IOException;
+  void commit(String tempFile, String committedFile) throws IOException;
+  void close() throws IOException;
+  WAL wal(String topicsDir, TopicPartition topicPart);
+  FileStatus[] listStatus(String path, PathFilter filter) throws IOException;
+  String url();
+  Configuration conf();
+}

--- a/src/main/java/io/confluent/copycat/hdfs/StorageFactory.java
+++ b/src/main/java/io/confluent/copycat/hdfs/StorageFactory.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.kafka.copycat.errors.CopycatException;
+import org.apache.velocity.exception.MethodInvocationException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class StorageFactory {
+  public static Storage createStorage(Class<? extends Storage> storageClass, Configuration conf, String url) {
+    try {
+      Constructor<? extends Storage> ctor =
+          storageClass.getConstructor(Configuration.class, String.class);
+      return ctor.newInstance(conf, url);
+    } catch (NoSuchMethodException | InvocationTargetException | MethodInvocationException | InstantiationException | IllegalAccessException e) {
+      throw new CopycatException(e);
+    }
+  }
+}

--- a/src/main/java/io/confluent/copycat/hdfs/WAL.java
+++ b/src/main/java/io/confluent/copycat/hdfs/WAL.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.kafka.copycat.errors.CopycatException;
+
+public interface WAL {
+  void acquireLease() throws CopycatException;
+  void append(String tempFile, String committedFile) throws CopycatException;
+  void apply() throws CopycatException;
+  void truncate() throws CopycatException;
+  void close() throws CopycatException;
+  String getLogFile();
+}

--- a/src/main/java/io/confluent/copycat/hdfs/WALEntry.java
+++ b/src/main/java/io/confluent/copycat/hdfs/WALEntry.java
@@ -14,15 +14,37 @@
 
 package io.confluent.copycat.hdfs;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.kafka.copycat.sink.SinkRecord;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 
-import io.confluent.copycat.avro.AvroData;
+public class WALEntry implements Writable {
 
-public interface RecordWriterProvider {
+  private String filename;
 
-  RecordWriter<Long, SinkRecord> getRecordWriter(Configuration conf, String fileName, SinkRecord record, AvroData avroData) throws
-                                                                                       IOException;
+  public WALEntry(String filename) {
+    this.filename = filename;
+  }
+
+  public WALEntry() {
+    filename = null;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    filename = Text.readString(in);
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    Text.writeString(out, filename);
+  }
+
 }

--- a/src/main/java/io/confluent/copycat/hdfs/WALFile.java
+++ b/src/main/java/io/confluent/copycat/hdfs/WALFile.java
@@ -1,0 +1,953 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.ChecksumException;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.Syncable;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.VersionMismatchException;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.SerializationFactory;
+import org.apache.hadoop.io.serializer.Serializer;
+import org.apache.hadoop.util.Options;
+import org.apache.hadoop.util.Time;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.rmi.server.UID;
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+public class WALFile {
+
+  private static final Log log = LogFactory.getLog(WALFile.class);
+  private static final byte INITIAL_VERSION = (byte) 0;
+  private static byte[] VERSION = new byte[]{
+      (byte) 'W', (byte) 'A', (byte) 'L', INITIAL_VERSION
+  };
+
+  private static final int SYNC_ESCAPE = -1;      // "length" of sync entries
+  private static final int SYNC_HASH_SIZE = 16;   // number of bytes in hash
+  private static final int SYNC_SIZE = 4 + SYNC_HASH_SIZE; // escape + hash
+
+  /**
+   * The number of bytes between sync points.
+   */
+  public static final int SYNC_INTERVAL = 100 * SYNC_SIZE;
+
+  private WALFile() {}
+
+  public static Writer createWriter(Configuration conf, Writer.Option... opts) throws IOException {
+    return new Writer(conf, opts);
+  }
+
+
+  public static class Writer implements Closeable, Syncable {
+
+    private Configuration conf;
+    private FSDataOutputStream out;
+    private DataOutputBuffer buffer = new DataOutputBuffer();
+    boolean ownOutputStream = true;
+    private boolean appendMode;
+    protected Serializer keySerializer;
+    protected Serializer valSerializer;
+
+    // Insert a globally unique 16-byte value every few entries, so that one
+    // can seek into the middle of a file and then synchronize with record
+    // starts and ends by scanning for this value.
+    long lastSyncPos;                     // position of last sync
+    byte[] sync;                          // 16 random bytes
+
+    {
+      try {
+        MessageDigest digester = MessageDigest.getInstance("MD5");
+        long time = Time.now();
+        digester.update((new UID() + "@" + time).getBytes(Charsets.UTF_8));
+        sync = digester.digest();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * A tag interface for all of the Reader options
+     */
+    public interface Option {}
+
+    public static Option file(Path value) {
+      return new FileOption(value);
+    }
+
+    public static Option bufferSize(int value) {
+      return new BufferSizeOption(value);
+    }
+
+    public static Option stream(FSDataOutputStream value) {
+      return new StreamOption(value);
+    }
+
+    public static Option replication(short value) {
+      return new ReplicationOption(value);
+    }
+
+    public static Option appendIfExists(boolean value) {
+      return new AppendIfExistsOption(value);
+    }
+
+    public static Option blockSize(long value) {
+      return new BlockSizeOption(value);
+    }
+
+
+    static class FileOption extends Options.PathOption implements Option {
+
+      FileOption(Path path) {
+        super(path);
+      }
+    }
+
+    static class StreamOption extends Options.FSDataOutputStreamOption
+        implements Option {
+
+      StreamOption(FSDataOutputStream stream) {
+        super(stream);
+      }
+    }
+
+    static class BufferSizeOption extends Options.IntegerOption
+        implements Option {
+
+      BufferSizeOption(int value) {
+        super(value);
+      }
+    }
+
+    static class BlockSizeOption extends Options.LongOption implements Option {
+
+      BlockSizeOption(long value) {
+        super(value);
+      }
+    }
+
+    static class ReplicationOption extends Options.IntegerOption
+        implements Option {
+
+      ReplicationOption(int value) {
+        super(value);
+      }
+    }
+
+    static class AppendIfExistsOption extends Options.BooleanOption implements Option {
+      AppendIfExistsOption(boolean value) {
+        super(value);
+      }
+    }
+
+
+    Writer(Configuration conf, Option... opts) throws IOException {
+      BlockSizeOption blockSizeOption =
+          Options.getOption(BlockSizeOption.class, opts);
+      BufferSizeOption bufferSizeOption =
+          Options.getOption(BufferSizeOption.class, opts);
+      ReplicationOption replicationOption =
+          Options.getOption(ReplicationOption.class, opts);
+
+      FileOption fileOption = Options.getOption(FileOption.class, opts);
+      AppendIfExistsOption appendIfExistsOption = Options.getOption(
+          AppendIfExistsOption.class, opts);
+      StreamOption streamOption = Options.getOption(StreamOption.class, opts);
+
+      // check consistency of options
+      if ((fileOption == null) == (streamOption == null)) {
+        throw new IllegalArgumentException("file or stream must be specified");
+      }
+      if (fileOption == null && (blockSizeOption != null ||
+                                 bufferSizeOption != null ||
+                                 replicationOption != null)) {
+        throw new IllegalArgumentException("file modifier options not " +
+                                           "compatible with stream");
+      }
+
+      FSDataOutputStream out;
+      boolean ownStream = fileOption != null;
+      if (ownStream) {
+        Path p = fileOption.getValue();
+        FileSystem fs;
+        fs = p.getFileSystem(conf);
+        int bufferSize = bufferSizeOption == null ? getBufferSize(conf) :
+                         bufferSizeOption.getValue();
+        short replication = replicationOption == null ?
+                            fs.getDefaultReplication(p) :
+                            (short) replicationOption.getValue();
+        long blockSize = blockSizeOption == null ? fs.getDefaultBlockSize(p) :
+                         blockSizeOption.getValue();
+
+        if (appendIfExistsOption != null && appendIfExistsOption.getValue()
+            && fs.exists(p)) {
+          // Read the file and verify header details
+          try (WALFile.Reader reader =
+                   new WALFile.Reader(conf, WALFile.Reader.file(p), new Reader.OnlyHeaderOption())){
+            if (reader.getVersion() != VERSION[3]) {
+              throw new VersionMismatchException(VERSION[3], reader.getVersion());
+            }
+            sync = reader.getSync();
+          }
+          out = fs.append(p, bufferSize);
+          this.appendMode = true;
+        } else {
+          out = fs.create(p, true, bufferSize, replication, blockSize);
+        }
+      } else {
+        out = streamOption.getValue();
+      }
+
+      init(conf, out, ownStream);
+    }
+
+    void init(Configuration conf, FSDataOutputStream out, boolean ownStream)
+        throws IOException {
+      this.conf = conf;
+      this.out = out;
+      this.ownOutputStream = ownStream;
+      SerializationFactory serializationFactory = new SerializationFactory(conf);
+      this.keySerializer = serializationFactory.getSerializer(WALEntry.class);
+      if (this.keySerializer == null) {
+        throw new IOException(
+            "Could not find a serializer for the Key class: '"
+            + WALEntry.class.getCanonicalName() + "'. "
+            + "Please ensure that the configuration '" +
+            CommonConfigurationKeys.IO_SERIALIZATIONS_KEY + "' is "
+            + "properly configured, if you're using"
+            + "custom serialization.");
+      }
+      this.keySerializer.open(buffer);
+      this.valSerializer = serializationFactory.getSerializer(WALEntry.class);
+      if (this.valSerializer == null) {
+        throw new IOException(
+            "Could not find a serializer for the Value class: '"
+            + WALEntry.class.getCanonicalName() + "'. "
+            + "Please ensure that the configuration '" +
+            CommonConfigurationKeys.IO_SERIALIZATIONS_KEY + "' is "
+            + "properly configured, if you're using"
+            + "custom serialization.");
+      }
+      this.valSerializer.open(buffer);
+      if (appendMode) {
+        sync();
+      } else {
+        writeFileHeader();
+      }
+    }
+
+    public void append(Writable key, Writable val)
+        throws IOException {
+      append((Object) key, (Object) val);
+    }
+
+    @SuppressWarnings("unchecked")
+    private synchronized void append(Object key, Object val)
+        throws IOException {
+      buffer.reset();
+
+      // Append the 'key'
+      keySerializer.serialize(key);
+      int keyLength = buffer.getLength();
+      if (keyLength < 0) {
+        throw new IOException("negative length keys not allowed: " + key);
+      }
+
+      valSerializer.serialize(val);
+
+      // Write the record out
+      checkAndWriteSync();                                // sync
+      out.writeInt(buffer.getLength());                   // total record length
+      out.writeInt(keyLength);                            // key portion length
+      out.write(buffer.getData(), 0, buffer.getLength()); // data
+    }
+
+    /** Returns the current length of the output file.
+     *
+     * <p>This always returns a synchronized position.  In other words,
+     * immediately after calling {@link WALFile.Reader#seek(long)} with a position
+     * returned by this method, {@link WALFile.Reader#next(Writable)} may be called.  However
+     * the key may be earlier in the file than key last written when this
+     * method was called (e.g., with block-compression, it may be the first key
+     * in the block that was being written when this method was called).
+     */
+    public synchronized long getLength() throws IOException {
+      return out.getPos();
+    }
+
+    private synchronized void checkAndWriteSync() throws IOException {
+      if (sync != null &&
+          out.getPos() >= lastSyncPos + SYNC_INTERVAL) { // time to emit sync
+        sync();
+      }
+    }
+
+    private void writeFileHeader()
+        throws IOException {
+      out.write(VERSION);                    // write the version
+      out.write(sync);                       // write the sync bytes
+      out.flush();                           // flush header
+    }
+
+
+    @Override
+    public synchronized void close() throws IOException {
+      keySerializer.close();
+      valSerializer.close();
+      if (out != null) {
+        // Close the underlying stream iff we own it...
+        if (ownOutputStream) {
+          out.close();
+        } else {
+          out.flush();
+        }
+        out = null;
+      }
+    }
+
+    @Override
+    public void sync() throws IOException {
+      if (sync != null && lastSyncPos != out.getPos()) {
+        out.writeInt(SYNC_ESCAPE);                // mark the start of the sync
+        out.write(sync);                          // write sync
+        lastSyncPos = out.getPos();               // update lastSyncPos
+      }
+    }
+
+    @Override
+    public void hsync() throws IOException {
+      if (out != null) {
+        out.hsync();
+      }
+    }
+
+    @Override
+    public void hflush() throws IOException {
+      if (out != null) {
+        out.hflush();
+      }
+    }
+  }
+
+  /**
+   * Get the configured buffer size
+   */
+  private static int getBufferSize(Configuration conf) {
+    return conf.getInt("io.file.buffer.size", 4096);
+  }
+
+  public static class Reader implements java.io.Closeable {
+
+    private String filename;
+    private FSDataInputStream in;
+    private DataOutputBuffer outBuf = new DataOutputBuffer();
+
+    private byte version;
+    private byte[] sync = new byte[SYNC_HASH_SIZE];
+    private byte[] syncCheck = new byte[SYNC_HASH_SIZE];
+    private boolean syncSeen;
+
+    private long headerEnd;
+    private long end;
+    private int keyLength;
+    private int recordLength;
+
+    private Configuration conf;
+
+    private DataInputBuffer valBuffer = null;
+    private DataInputStream valIn = null;
+    private Deserializer keyDeserializer;
+    private Deserializer valDeserializer;
+
+    /**
+     * A tag interface for all of the Reader options
+     */
+    public interface Option {
+
+    }
+
+    /**
+     * Create an option to specify the path name of the sequence file.
+     *
+     * @param value the path to read
+     * @return a new option
+     */
+    public static Option file(Path value) {
+      return new FileOption(value);
+    }
+
+    /**
+     * Create an option to specify the stream with the sequence file.
+     *
+     * @param value the stream to read.
+     * @return a new option
+     */
+    public static Option stream(FSDataInputStream value) {
+      return new InputStreamOption(value);
+    }
+
+    /**
+     * Create an option to specify the starting byte to read.
+     *
+     * @param value the number of bytes to skip over
+     * @return a new option
+     */
+    public static Option start(long value) {
+      return new StartOption(value);
+    }
+
+    /**
+     * Create an option to specify the number of bytes to read.
+     *
+     * @param value the number of bytes to read
+     * @return a new option
+     */
+    public static Option length(long value) {
+      return new LengthOption(value);
+    }
+
+    /**
+     * Create an option with the buffer size for reading the given pathname.
+     *
+     * @param value the number of bytes to buffer
+     * @return a new option
+     */
+    public static Option bufferSize(int value) {
+      return new BufferSizeOption(value);
+    }
+
+    private static class FileOption extends Options.PathOption
+        implements Option {
+
+      private FileOption(Path value) {
+        super(value);
+      }
+    }
+
+    private static class InputStreamOption
+        extends Options.FSDataInputStreamOption
+        implements Option {
+
+      private InputStreamOption(FSDataInputStream value) {
+        super(value);
+      }
+    }
+
+    private static class StartOption extends Options.LongOption
+        implements Option {
+
+      private StartOption(long value) {
+        super(value);
+      }
+    }
+
+    private static class LengthOption extends Options.LongOption
+        implements Option {
+
+      private LengthOption(long value) {
+        super(value);
+      }
+    }
+
+    private static class BufferSizeOption extends Options.IntegerOption
+        implements Option {
+
+      private BufferSizeOption(int value) {
+        super(value);
+      }
+    }
+
+    // only used directly
+    private static class OnlyHeaderOption extends Options.BooleanOption
+        implements Option {
+
+      private OnlyHeaderOption() {
+        super(true);
+      }
+    }
+
+    public Reader(Configuration conf, Option... opts) throws IOException {
+      // Look up the options, these are null if not set
+      FileOption fileOpt = Options.getOption(FileOption.class, opts);
+      InputStreamOption streamOpt =
+          Options.getOption(InputStreamOption.class, opts);
+      StartOption startOpt = Options.getOption(StartOption.class, opts);
+      LengthOption lenOpt = Options.getOption(LengthOption.class, opts);
+      BufferSizeOption bufOpt = Options.getOption(BufferSizeOption.class, opts);
+      OnlyHeaderOption headerOnly =
+          Options.getOption(OnlyHeaderOption.class, opts);
+      // check for consistency
+      if ((fileOpt == null) == (streamOpt == null)) {
+        throw new
+            IllegalArgumentException("File or stream option must be specified");
+      }
+      if (fileOpt == null && bufOpt != null) {
+        throw new IllegalArgumentException("buffer size can only be set when" +
+                                           " a file is specified.");
+      }
+      // figure out the real values
+      Path filename = null;
+      FSDataInputStream file;
+      final long len;
+      if (fileOpt != null) {
+        filename = fileOpt.getValue();
+        FileSystem fs = filename.getFileSystem(conf);
+        int bufSize = bufOpt == null ? getBufferSize(conf) : bufOpt.getValue();
+        len = null == lenOpt
+              ? fs.getFileStatus(filename).getLen()
+              : lenOpt.getValue();
+        file = openFile(fs, filename, bufSize, len);
+      } else {
+        len = null == lenOpt ? Long.MAX_VALUE : lenOpt.getValue();
+        file = streamOpt.getValue();
+      }
+      long start = startOpt == null ? 0 : startOpt.getValue();
+      // really set up
+      initialize(filename, file, start, len, conf, headerOnly != null);
+    }
+
+    /**
+     * Common work of the constructors.
+     */
+    private void initialize(Path filename, FSDataInputStream in,
+                            long start, long length, Configuration conf,
+                            boolean tempReader) throws IOException {
+      if (in == null) {
+        throw new IllegalArgumentException("in == null");
+      }
+      this.filename = filename == null ? "<unknown>" : filename.toString();
+      this.in = in;
+      this.conf = conf;
+      boolean succeeded = false;
+      try {
+        seek(start);
+        this.end = this.in.getPos() + length;
+        // if it wrapped around, use the max
+        if (end < length) {
+          end = Long.MAX_VALUE;
+        }
+        init(tempReader);
+        succeeded = true;
+      } finally {
+        if (!succeeded) {
+          IOUtils.cleanup(log, this.in);
+        }
+      }
+    }
+
+    /**
+     * Override this method to specialize the type of {@link FSDataInputStream} returned.
+     *
+     * @param fs         The file system used to open the file.
+     * @param file       The file being read.
+     * @param bufferSize The buffer size used to read the file.
+     * @param length     The length being read if it is >= 0.  Otherwise, the length is not
+     *                   available.
+     * @return The opened stream.
+     */
+    protected FSDataInputStream openFile(FileSystem fs, Path file,
+                                         int bufferSize, long length) throws IOException {
+      return fs.open(file, bufferSize);
+    }
+
+    /**
+     * Initialize the {@link Reader}
+     *
+     * @param tempReader <code>true</code> if we are constructing a temporary and hence do not
+     *                   initialize every component; <code>false</code> otherwise.
+     */
+    private void init(boolean tempReader) throws IOException {
+      byte[] versionBlock = new byte[VERSION.length];
+      in.readFully(versionBlock);
+
+      if ((versionBlock[0] != VERSION[0]) ||
+          (versionBlock[1] != VERSION[1]) ||
+          (versionBlock[2] != VERSION[2])) {
+        throw new IOException(this + " not a WALFile");
+      }
+
+      // Set 'version'
+      version = versionBlock[3];
+      if (version > VERSION[3]) {
+        throw new VersionMismatchException(VERSION[3], version);
+      }
+
+      in.readFully(sync);                       // read sync bytes
+      headerEnd = in.getPos();                  // record end of header
+
+      // Initialize... *not* if this we are constructing a temporary Reader
+      if (!tempReader) {
+        valBuffer = new DataInputBuffer();
+        valIn = valBuffer;
+
+        SerializationFactory serializationFactory =
+            new SerializationFactory(conf);
+        this.keyDeserializer =
+            getDeserializer(serializationFactory, WALEntry.class);
+        if (this.keyDeserializer == null) {
+          throw new IOException(
+              "Could not find a deserializer for the Key class: '"
+              + WALFile.class.getCanonicalName() + "'. "
+              + "Please ensure that the configuration '" +
+              CommonConfigurationKeys.IO_SERIALIZATIONS_KEY + "' is "
+              + "properly configured, if you're using "
+              + "custom serialization.");
+        }
+
+        this.keyDeserializer.open(valBuffer);
+
+        this.valDeserializer =
+            getDeserializer(serializationFactory, WALEntry.class);
+        if (this.valDeserializer == null) {
+          throw new IOException(
+              "Could not find a deserializer for the Value class: '"
+              + WALEntry.class.getCanonicalName() + "'. "
+              + "Please ensure that the configuration '" +
+              CommonConfigurationKeys.IO_SERIALIZATIONS_KEY + "' is "
+              + "properly configured, if you're using "
+              + "custom serialization.");
+        }
+        this.valDeserializer.open(valIn);
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Deserializer getDeserializer(SerializationFactory sf, Class c) {
+      return sf.getDeserializer(c);
+    }
+
+    /**
+     * Close the file.
+     */
+    @Override
+    public synchronized void close() throws IOException {
+      if (keyDeserializer != null) {
+        keyDeserializer.close();
+      }
+      if (valDeserializer != null) {
+        valDeserializer.close();
+      }
+
+      // Close the input-stream
+      in.close();
+    }
+
+    private byte[] getSync() {
+      return sync;
+    }
+
+    private byte getVersion() {
+      return version;
+    }
+
+    /**
+     * Returns the configuration used for this file.
+     */
+    Configuration getConf() {
+      return conf;
+    }
+
+
+    /**
+     * Position valLenIn/valIn to the 'value' corresponding to the 'current' key
+     */
+    private synchronized void seekToCurrentValue() throws IOException {
+      valBuffer.reset();
+    }
+
+    /**
+     * Get the 'value' corresponding to the last read 'key'.
+     *
+     * @param val : The 'value' to be read.
+     */
+    public synchronized void getCurrentValue(Writable val)
+        throws IOException {
+      if (val instanceof Configurable) {
+        ((Configurable) val).setConf(this.conf);
+      }
+      // Position stream to 'current' value
+      seekToCurrentValue();
+
+      val.readFields(valIn);
+      if (valIn.read() > 0) {
+        log.info("available bytes: " + valIn.available());
+        throw new IOException(val + " read " + (valBuffer.getPosition() - keyLength)
+                              + " bytes, should read " +
+                              (valBuffer.getLength() - keyLength));
+      }
+    }
+
+    /**
+     * Get the 'value' corresponding to the last read 'key'.
+     *
+     * @param val : The 'value' to be read.
+     */
+    public synchronized Object getCurrentValue(Object val)
+        throws IOException {
+      if (val instanceof Configurable) {
+        ((Configurable) val).setConf(this.conf);
+      }
+
+      // Position stream to 'current' value
+      seekToCurrentValue();
+      val = deserializeValue(val);
+      if (valIn.read() > 0) {
+        log.info("available bytes: " + valIn.available());
+        throw new IOException(val + " read " + (valBuffer.getPosition() - keyLength)
+                              + " bytes, should read " +
+                              (valBuffer.getLength() - keyLength));
+      }
+      return val;
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object deserializeValue(Object val) throws IOException {
+      return valDeserializer.deserialize(val);
+    }
+
+    /**
+     * Read the next key in the file into <code>key</code>, skipping its value.  True if another
+     * entry exists, and false at end of file.
+     */
+    public synchronized boolean next(Writable key) throws IOException {
+      if (key.getClass() != WALEntry.class) {
+        throw new IOException("wrong key class: " + key.getClass().getName()
+                              + " is not " + WALEntry.class);
+      }
+
+      outBuf.reset();
+
+      keyLength = next(outBuf);
+      if (keyLength < 0) {
+        return false;
+      }
+
+      valBuffer.reset(outBuf.getData(), outBuf.getLength());
+
+      key.readFields(valBuffer);
+      valBuffer.mark(0);
+      if (valBuffer.getPosition() != keyLength) {
+        throw new IOException(key + " read " + valBuffer.getPosition()
+                              + " bytes, should read " + keyLength);
+      }
+
+
+      return true;
+    }
+
+    /**
+     * Read the next key/value pair in the file into <code>key</code> and <code>val</code>.  Returns
+     * true if such a pair exists and false when at end of file
+     */
+    public synchronized boolean next(Writable key, Writable val)
+        throws IOException {
+      if (val.getClass() != WALEntry.class) {
+        throw new IOException("wrong value class: " + val + " is not " + WALEntry.class);
+      }
+
+      boolean more = next(key);
+
+      if (more) {
+        getCurrentValue(val);
+      }
+
+      return more;
+    }
+
+    /** Read the next key/value pair in the file into <code>buffer</code>.
+     * Returns the length of the key read, or -1 if at end of file.  The length
+     * of the value may be computed by calling buffer.getLength() before and
+     * after calls to this method. */
+    synchronized int next(DataOutputBuffer buffer) throws IOException {
+      try {
+        int length = readRecordLength();
+        if (length == -1) {
+          return -1;
+        }
+        int keyLength = in.readInt();
+        buffer.write(in, length);
+        return keyLength;
+      } catch (ChecksumException e) {             // checksum failure
+        handleChecksumException(e);
+        return next(buffer);
+      }
+    }
+
+    /**
+     * Read and return the next record length, potentially skipping over a sync block.
+     *
+     * @return the length of the next record or -1 if there is no next record
+     */
+    private synchronized int readRecordLength() throws IOException {
+      if (in.getPos() >= end) {
+        return -1;
+      }
+      int length = in.readInt();
+      if (sync != null &&
+          length == SYNC_ESCAPE) {              // process a sync entry
+        in.readFully(syncCheck);                // read syncCheck
+        if (!Arrays.equals(sync, syncCheck))    // check it
+        {
+          throw new IOException("File is corrupt!");
+        }
+        syncSeen = true;
+        if (in.getPos() >= end) {
+          return -1;
+        }
+        length = in.readInt();                  // re-read length
+      } else {
+        syncSeen = false;
+      }
+
+      return length;
+    }
+
+    /**
+     * Read the next key in the file, skipping its value.  Return null at end of file.
+     */
+    public synchronized Object next(Object key) throws IOException {
+      if (key != null && key.getClass() != WALEntry.class) {
+        throw new IOException("wrong key class: " + key.getClass().getName()
+                              + " is not " + WALEntry.class);
+      }
+
+      outBuf.reset();
+      keyLength = next(outBuf);
+      if (keyLength < 0) {
+        return null;
+      }
+      valBuffer.reset(outBuf.getData(), outBuf.getLength());
+      key = deserializeKey(key);
+      valBuffer.mark(0);
+      if (valBuffer.getPosition() != keyLength) {
+        throw new IOException(key + " read " + valBuffer.getPosition()
+                              + " bytes, should read " + keyLength);
+      }
+      return key;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object deserializeKey(Object key) throws IOException {
+      return keyDeserializer.deserialize(key);
+    }
+
+    private void handleChecksumException(ChecksumException e)
+        throws IOException {
+      if (this.conf.getBoolean("io.skip.checksum.errors", false)) {
+        log.warn("Bad checksum at " + getPosition() + ". Skipping entries.");
+        sync(getPosition() + this.conf.getInt("io.bytes.per.checksum", 512));
+      } else {
+        throw e;
+      }
+    }
+
+    /**
+     * disables sync. often invoked for tmp files
+     */
+    synchronized void ignoreSync() {
+      sync = null;
+    }
+
+    /**
+     * Set the current byte position in the input file.
+     *
+     * <p>The position passed must be a position returned by {@link WALFile.Writer#getLength()}
+     * when writing this file.  To seek to an arbitrary position, use {@link
+     * WALFile.Reader#sync(long)}.
+     */
+    public synchronized void seek(long position) throws IOException {
+      in.seek(position);
+    }
+
+    /**
+     * Seek to the next sync mark past a given position.
+     */
+    public synchronized void sync(long position) throws IOException {
+      if (position + SYNC_SIZE >= end) {
+        seek(end);
+        return;
+      }
+
+      if (position < headerEnd) {
+        // seek directly to first record
+        in.seek(headerEnd);
+        // note the sync marker "seen" in the header
+        syncSeen = true;
+        return;
+      }
+
+      try {
+        seek(position + 4);                         // skip escape
+        in.readFully(syncCheck);
+        int syncLen = sync.length;
+        for (int i = 0; in.getPos() < end; i++) {
+          int j = 0;
+          for (; j < syncLen; j++) {
+            if (sync[j] != syncCheck[(i + j) % syncLen]) {
+              break;
+            }
+          }
+          if (j == syncLen) {
+            in.seek(in.getPos() - SYNC_SIZE);     // position before sync
+            return;
+          }
+          syncCheck[i % syncLen] = in.readByte();
+        }
+      } catch (ChecksumException e) {             // checksum failure
+        handleChecksumException(e);
+      }
+    }
+
+    /**
+     * Returns true iff the previous call to next passed a sync mark.
+     */
+    public synchronized boolean syncSeen() {
+      return syncSeen;
+    }
+
+    /**
+     * Return the current byte position in the input file.
+     */
+    public synchronized long getPosition() throws IOException {
+      return in.getPos();
+    }
+
+    /**
+     * Returns the name of the file.
+     */
+    @Override
+    public String toString() {
+      return filename;
+    }
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/CommittedFileFilterTest.java
+++ b/src/test/java/io/confluent/copycat/hdfs/CommittedFileFilterTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CommittedFileFilterTest {
+  private static FileSystem fs;
+  private static Path ROOT_PATH = new Path(System.getProperty(
+      "test.build.data", "build/test/data"));
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
+    fs = FileSystem.get(conf);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    fs.close();
+  }
+
+  @Test
+  public void testCommitedFileFilter() throws IOException {
+
+    Path log = new Path(ROOT_PATH, "log");
+    Path oldLog = new Path(ROOT_PATH, "log.1");
+
+    String temp_name = UUID.randomUUID().toString() + "_" + "tmp";
+    Path tmp = new Path(ROOT_PATH, temp_name);
+
+    Path valid1 = new Path(ROOT_PATH, "a_b");
+    Path valid2 = new Path(ROOT_PATH, "a_1");
+    Path valid3 = new Path(ROOT_PATH, "1_b");
+    Path valid4 = new Path(ROOT_PATH, "1_2");
+
+    Path invalid1 = new Path(ROOT_PATH, "1_2_3");
+    Path invalid2 = new Path(ROOT_PATH, "a_b_c_d");
+    Path invalid3 = new Path(ROOT_PATH, "tmp");
+    Path invalid4 = new Path(ROOT_PATH, "a.b");
+
+    fs.createNewFile(log);
+    fs.createNewFile(oldLog);
+    fs.createNewFile(tmp);
+
+    fs.createNewFile(valid1);
+    fs.createNewFile(valid2);
+    fs.createNewFile(valid3);
+    fs.createNewFile(valid4);
+
+    fs.createNewFile(invalid1);
+    fs.createNewFile(invalid2);
+    fs.createNewFile(invalid3);
+    fs.createNewFile(invalid4);
+
+    FileStatus[] statuses = fs.listStatus(ROOT_PATH, new CommittedFileFilter());
+    Set<String> files = new HashSet<>();
+    for (FileStatus status : statuses) {
+      files.add(status.getPath().getName());
+    }
+
+    assertEquals(files.size(), 4);
+    assertTrue(files.contains(valid1.getName()));
+    assertTrue(files.contains(valid2.getName()));
+    assertTrue(files.contains(valid3.getName()));
+    assertTrue(files.contains(valid4.getName()));
+    fs.deleteOnExit(ROOT_PATH);
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/copycat/hdfs/FailureRecoveryTest.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.kafka.copycat.data.Schema;
+import org.apache.kafka.copycat.data.Struct;
+import org.apache.kafka.copycat.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import io.confluent.copycat.hdfs.utils.Data;
+import io.confluent.copycat.hdfs.utils.MemoryRecordWriter;
+import io.confluent.copycat.hdfs.utils.MemoryRecordWriterProvider;
+import io.confluent.copycat.hdfs.utils.MemoryStorage;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
+
+  @Before
+  public void setUp() throws Exception {
+    dfsCluster = false;
+    super.setUp();
+  }
+
+  @Override
+  protected Properties createProps() {
+    Properties props = super.createProps();
+    props.put(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG, MemoryStorage.class.getName());
+    props.put(HdfsSinkConnectorConfig.RECORD_WRITER_PROVIDER_CLASS_CONFIG,
+              MemoryRecordWriterProvider.class.getName());
+    return props;
+  }
+
+  @Test
+  public void testCommitFailure() throws Exception {
+    Properties props = createProps();
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = 0; offset < 7; offset++) {
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
+      sinkRecords.add(sinkRecord);
+    }
+
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    MemoryStorage storage = (MemoryStorage) hdfsWriter.getStorage();
+    storage.setFailure(MemoryStorage.Failure.appendFailure);
+
+    hdfsWriter.write(sinkRecords);
+    assertEquals(context.backoff(), connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+
+    Map<String, List<Object>> data = Data.getData();
+
+    String logFile = FileUtils.logFileName(url, topicsDir, TOPIC_PARTITION);
+    List<Object> content = data.get(logFile);
+    assertEquals(null, content);
+
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    content = data.get(logFile);
+    assertEquals(null, content);
+
+    Thread.sleep(context.backoff());
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    content = data.get(logFile);
+    assertEquals(2, content.size());
+
+    hdfsWriter.close();
+  }
+
+  @Test
+  public void testWriterFailureMultiPartitions() throws Exception {
+    Properties props = createProps();
+
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
+    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 0L));
+    sinkRecords.add(new SinkRecord(TOPIC, PARTITION2, Schema.STRING_SCHEMA, key, schema, record, 0L));
+
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    hdfsWriter.write(sinkRecords);
+    sinkRecords.clear();
+
+    for (long offset = 1; offset < 7; offset++) {
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
+      sinkRecords.add(sinkRecord);
+    }
+
+    for (long offset = 1; offset < 7; offset++) {
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION2, Schema.STRING_SCHEMA, key, schema, record, offset);
+      sinkRecords.add(sinkRecord);
+    }
+
+    MemoryRecordWriter writer = (MemoryRecordWriter) hdfsWriter.getRecordWriter(TOPIC_PARTITION);
+    String tempFileName = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
+
+    writer.setFailure(MemoryRecordWriter.Failure.writeFailure);
+    hdfsWriter.write(sinkRecords);
+    assertEquals(context.backoff(), connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+
+
+    Map<String, List<Object>> data = Data.getData();
+    long[] validOffsets = {-1, 2, 5};
+    for (int i = 1; i < validOffsets.length; i++) {
+      long startOffset = validOffsets[i - 1] + 1;
+      long endOffset = validOffsets[i];
+      String path = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION2, startOffset, endOffset);
+      long size = endOffset - startOffset + 1;
+      List<Object> records = data.get(path);
+      assertEquals(size, records.size());
+    }
+
+    writer.setFailure(MemoryRecordWriter.Failure.closeFailure);
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    assertEquals(context.backoff(), connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+
+    List<Object> content = data.get(tempFileName);
+    assertEquals(1, content.size());
+    for (int i = 0; i < content.size(); ++i) {
+      SinkRecord refSinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
+      assertEquals(refSinkRecord, content.get(i));
+    }
+
+    Thread.sleep(context.backoff());
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    assertEquals(3, content.size());
+    for (int i = 0; i < content.size(); ++i) {
+      SinkRecord refSinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
+      assertEquals(refSinkRecord, content.get(i));
+    }
+
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.close();
+  }
+
+  @Test
+  public void testWriterFailure() throws Exception {
+    Properties props = createProps();
+
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    ArrayList<SinkRecord> sinkRecords = new ArrayList<>();
+    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 0L));
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    hdfsWriter.write(sinkRecords);
+
+    sinkRecords.clear();
+    for (long offset = 1; offset < 7; offset++) {
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
+      sinkRecords.add(sinkRecord);
+    }
+
+    MemoryRecordWriter writer = (MemoryRecordWriter) hdfsWriter.getRecordWriter(TOPIC_PARTITION);
+    writer.setFailure(MemoryRecordWriter.Failure.writeFailure);
+    hdfsWriter.write(sinkRecords);
+    assertEquals(context.backoff(), connectorConfig.getLong(
+        HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG));
+
+    writer.setFailure(MemoryRecordWriter.Failure.closeFailure);
+    // nothing happens as we the retry back off hasn't yet passed
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    Map<String, List<Object>> data = Data.getData();
+    String tempFileName = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
+    List<Object> content = data.get(tempFileName);
+    assertEquals(1, content.size());
+    for (int i = 0; i < content.size(); ++i) {
+      SinkRecord refSinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
+      assertEquals(refSinkRecord, content.get(i));
+    }
+
+    Thread.sleep(context.backoff());
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+
+    tempFileName = hdfsWriter.getTempFileNames(TOPIC_PARTITION);
+    content = data.get(tempFileName);
+    assertEquals(3, content.size());
+    for (int i = 0; i < content.size(); ++i) {
+      SinkRecord refSinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
+      assertEquals(refSinkRecord, content.get(i));
+    }
+
+    hdfsWriter.write(new ArrayList<SinkRecord>());
+    hdfsWriter.close();
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/copycat/hdfs/HdfsSinkTaskTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.copycat.data.Schema;
+import org.apache.kafka.copycat.data.Struct;
+import org.apache.kafka.copycat.sink.SinkRecord;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import io.confluent.copycat.avro.AvroData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HdfsSinkTaskTest extends HdfsSinkConnectorTestBase {
+
+  @Test
+  public void testSinkTaskStart() throws Exception {
+    createCommittedFiles();
+
+    Properties props = createProps();
+    HdfsSinkTask task = new HdfsSinkTask();
+
+    task.initialize(context);
+    task.start(props);
+
+    Map<TopicPartition, Long> offsets = context.offsets();
+    assertEquals(offsets.size(), 2);
+    assertTrue(offsets.containsKey(TOPIC_PARTITION));
+    assertEquals((long) offsets.get(TOPIC_PARTITION), 20);
+    assertTrue(offsets.containsKey(TOPIC_PARTITION2));
+    assertEquals((long) offsets.get(TOPIC_PARTITION2), 45);
+
+    task.stop();
+  }
+
+  @Test
+  public void testSinkTaskStartWithRecovery() throws Exception {
+    Map<TopicPartition, List<String>> tempfiles = new HashMap<>();
+    List<String> list1 = new ArrayList<>();
+    list1.add(FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION));
+    list1.add(FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION));
+    tempfiles.put(TOPIC_PARTITION, list1);
+
+    List<String> list2 = new ArrayList<>();
+    list2.add(FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION2));
+    list2.add(FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION2));
+    tempfiles.put(TOPIC_PARTITION2, list2);
+
+    Map<TopicPartition, List<String>> committedFiles = new HashMap<>();
+    List<String> list3 = new ArrayList<>();
+    list3.add(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, 100, 200));
+    list3.add(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, 201, 300));
+    committedFiles.put(TOPIC_PARTITION, list3);
+
+    List<String> list4 = new ArrayList<>();
+    list4.add(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION2, 400, 500));
+    list4.add(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION2, 501, 800));
+    committedFiles.put(TOPIC_PARTITION2, list4);
+
+    for (TopicPartition tp : tempfiles.keySet()) {
+      for (String file : tempfiles.get(tp)) {
+        fs.createNewFile(new Path(file));
+      }
+    }
+    createWALs(tempfiles, committedFiles);
+
+    Properties props = createProps();
+    HdfsSinkTask task = new HdfsSinkTask();
+
+    task.initialize(context);
+    task.start(props);
+
+    Map<TopicPartition, Long> offsets = context.offsets();
+    assertEquals(offsets.size(), 2);
+    assertTrue(offsets.containsKey(TOPIC_PARTITION));
+    assertEquals((long) offsets.get(TOPIC_PARTITION), 300);
+    assertTrue(offsets.containsKey(TOPIC_PARTITION2));
+    assertEquals((long) offsets.get(TOPIC_PARTITION2), 800);
+
+    task.stop();
+  }
+
+  @Test
+  public void testSinkTaskPut() throws Exception {
+    Properties props = createProps();
+    HdfsSinkTask task = new HdfsSinkTask();
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
+    for (TopicPartition tp: assignment) {
+      for (long offset = 0; offset < 7; offset++) {
+        SinkRecord sinkRecord =
+            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
+        sinkRecords.add(sinkRecord);
+      }
+    }
+    task.initialize(context);
+    task.start(props);
+    task.put(sinkRecords);
+    task.stop();
+
+    AvroData avroData = task.getAvroData();
+    long[] validOffsets = {-1, 2, 5, 6};
+
+    for (TopicPartition tp : assignment) {
+      for (int j = 1; j < validOffsets.length; ++j) {
+        long startOffset = validOffsets[j - 1] + 1;
+        long endOffset = validOffsets[j];
+        Path path = new Path(FileUtils.committedFileName(url, topicsDir, tp, startOffset, endOffset));
+        Collection<Object> records = readAvroFile(path);
+        long size = endOffset - startOffset + 1;
+        assertEquals(records.size(), size);
+        for (Object avroRecord : records) {
+          assertEquals(avroRecord, avroData.fromCopycatData(schema, record));
+        }
+      }
+    }
+  }
+
+  private void createCommittedFiles() throws IOException {
+    String file1 = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, 0, 10);
+    String file2 = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, 11, 20);
+    String file3 = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION2, 21, 40);
+    String file4 = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION2, 41, 45);
+    fs.createNewFile(new Path(file1));
+    fs.createNewFile(new Path(file2));
+    fs.createNewFile(new Path(file3));
+    fs.createNewFile(new Path(file4));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void createWALs(Map<TopicPartition, List<String>> tempfiles,
+                          Map<TopicPartition, List<String>> committedFiles) throws Exception {
+
+    Class<? extends Storage> storageClass = (Class<? extends Storage>)
+        Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
+    Storage storage = StorageFactory.createStorage(storageClass, conf, url);
+
+    for (TopicPartition tp: tempfiles.keySet()) {
+      WAL wal = storage.wal(topicsDir, tp);
+      List<String> templist = tempfiles.get(tp);
+      List<String> committedList = committedFiles.get(tp);
+      for (int i = 0; i < templist.size(); ++i) {
+        wal.append(templist.get(i), committedList.get(i));
+      }
+      wal.close();
+    }
+  }
+}
+

--- a/src/test/java/io/confluent/copycat/hdfs/HdfsWriterTest.java
+++ b/src/test/java/io/confluent/copycat/hdfs/HdfsWriterTest.java
@@ -1,141 +1,309 @@
 /**
  * Copyright 2015 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  **/
 
 package io.confluent.copycat.hdfs;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.copycat.data.Schema;
+import org.apache.kafka.copycat.data.Struct;
+import org.apache.kafka.copycat.sink.SinkRecord;
 import org.junit.Test;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Properties;
-
-import io.confluent.copycat.connector.TopicPartition;
-import io.confluent.copycat.data.GenericRecord;
-import io.confluent.copycat.errors.CopycatException;
-import io.confluent.copycat.sink.SinkRecord;
-import io.confluent.copycat.util.AvroData;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 public class HdfsWriterTest extends HdfsSinkConnectorTestBase {
 
   @Test
-  public void testWriteRecord() throws IOException, CopycatException {
-    Properties props = createProps();
-    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
-    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig);
+  public void testWriteRecord() throws Exception {
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    hdfsWriter.recover(TOPIC_PARTITION);
 
-    String topicsDir = connectorConfig.getString(HdfsSinkConnectorConfig.TOPIC_DIR_CONFIG);
-    String topic = "topic";
-    int partition = 0;
     String key = "key";
-    GenericRecord record = createRecord();
-    TopicPartition topicPart = new TopicPartition(topic, partition);
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
 
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
     for (long offset = 0; offset < 7; offset++) {
-      SinkRecord sinkRecord = new SinkRecord(topic, partition, key, record, offset);
-      hdfsWriter.writeRecord(topicPart, sinkRecord);
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
+
+      sinkRecords.add(sinkRecord);
     }
+    hdfsWriter.write(sinkRecords);
     hdfsWriter.close();
 
     long[] validOffsets = {-1, 2, 5, 6};
+
     for (int i = 1; i < validOffsets.length; i++) {
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, topicPart, validOffsets[i]));
+      long startOffset = validOffsets[i - 1] + 1;
+      long endOffset = validOffsets[i];
+      Path path =
+          new Path(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, startOffset, endOffset));
       Collection<Object> records = readAvroFile(path);
-      long size = validOffsets[i] - validOffsets[i - 1];
-      assertEquals(records.size(), size);
-      for (Object avroRecord: records) {
-        assertEquals(avroRecord, AvroData.convertToAvro(record));
+      long size = endOffset - startOffset + 1;
+      assertEquals(size, records.size());
+      for (Object avroRecord : records) {
+        assertEquals(avroData.fromCopycatData(schema, record), avroRecord);
       }
     }
-
-    long[] inValidOffsets = {0, 1, 3, 4};
-    for (long offset: inValidOffsets) {
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, topicPart, offset));
-      assertFalse(fs.exists(path));
-    }
   }
 
   @Test
-  public void testGetPreviousOffsets() throws IOException, CopycatException {
-    Properties props = createProps();
-    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+  @SuppressWarnings("unchecked")
+  public void testRecovery() throws Exception {
+    fs.delete(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)), true);
 
-    String topicsDir = connectorConfig.getString(HdfsSinkConnectorConfig.TOPIC_DIR_CONFIG);
-    String topic = "topic";
-    int partition = 0;
-    TopicPartition topicPart = new TopicPartition(topic, partition);
-    long[] offsets = {3, 6};
-    for (long offset: offsets) {
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, topicPart, offset));
-      fs.createNewFile(path);
+    Class<? extends Storage> storageClass = (Class<? extends Storage>)
+        Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
+    Storage storage = StorageFactory.createStorage(storageClass, conf, url);
+
+    WAL wal = storage.wal(topicsDir, TOPIC_PARTITION);
+    Set<String> committedFiles = new HashSet<>();
+    for (int i = 0; i < 5; ++i) {
+      long startOffset = i * 10;
+      long endOffset = (i + 1) * 10 - 1;
+      String tempfile = FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION);
+      fs.createNewFile(new Path(tempfile));
+      String committedFile = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, startOffset,
+                                                         endOffset);
+      committedFiles.add(committedFile);
+      wal.append(tempfile, committedFile);
     }
-    Path path = new Path(FileUtils.tempFileName(url, topicsDir, topicPart));
-    fs.createNewFile(path);
+    wal.close();
 
-    path = new Path(FileUtils.fileName(url, topicsDir, topicPart, "abcd"));
-    fs.createNewFile(path);
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    hdfsWriter.recover(TOPIC_PARTITION);
 
-    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig);
-    Map<TopicPartition, Long> previousOffsets = hdfsWriter.getPreviousOffsets();
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 50);
+
+    Collection<SinkRecord> sinkRecords = Collections.singletonList(sinkRecord);
+    hdfsWriter.write(sinkRecords);
     hdfsWriter.close();
 
-    assertTrue(previousOffsets.containsKey(topicPart));
-    long previousOffset = previousOffsets.get(topicPart);
-    assertEquals(previousOffset, 6L);
+    committedFiles.add(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, 50, 50));
+    FileStatus[] statuses =
+        fs.listStatus(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)),
+                      new CommittedFileFilter());
+    for (FileStatus status : statuses) {
+      assertTrue(committedFiles.contains(status.getPath().toString()));
+    }
   }
 
   @Test
-  public void testWriteRecordNonZeroInitailOffset() throws IOException, CopycatException {
-    Properties props = createProps();
-    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
-    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig);
+  public void testWriteRecordMultiplePartitions() throws Exception {
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
 
-    String topicsDir = connectorConfig.getString(HdfsSinkConnectorConfig.TOPIC_DIR_CONFIG);
-    String topic = "topic";
-    int partition = 0;
-    String key = "key";
-    GenericRecord record = createRecord();
-    TopicPartition topicPart = new TopicPartition(topic, partition);
-
-    for (long offset = 3; offset < 10; offset++) {
-      SinkRecord sinkRecord = new SinkRecord(topic, partition, key, record, offset);
-      hdfsWriter.writeRecord(topicPart, sinkRecord);
+    for (TopicPartition tp: assignment) {
+      hdfsWriter.recover(tp);
     }
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
+    for (TopicPartition tp: assignment) {
+      for (long offset = 0; offset < 7; offset++) {
+        SinkRecord sinkRecord =
+            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
+        sinkRecords.add(sinkRecord);
+      }
+    }
+    hdfsWriter.write(sinkRecords);
+    hdfsWriter.close();
+
+    long[] validOffsets = {-1, 2, 5, 6};
+
+    for (TopicPartition tp : assignment) {
+      for (int j = 1; j < validOffsets.length; ++j) {
+        long startOffset = validOffsets[j - 1] + 1;
+        long endOffset = validOffsets[j];
+        Path path = new Path(
+            FileUtils.committedFileName(url, topicsDir, tp, startOffset, endOffset));
+        Collection<Object> records = readAvroFile(path);
+        long size = endOffset - startOffset + 1;
+        assertEquals(records.size(), size);
+        for (Object avroRecord : records) {
+          assertEquals(avroRecord, avroData.fromCopycatData(schema, record));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testGetPreviousOffsets() throws Exception {
+    long[] startOffsets = {0, 3};
+    long[] endOffsets = {2, 5};
+
+    for (int i = 0; i < startOffsets.length; ++i) {
+      Path path = new Path(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, startOffsets[i],
+                                               endOffsets[i]));
+      fs.createNewFile(path);
+    }
+    Path path = new Path(FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION));
+    fs.createNewFile(path);
+
+    path = new Path(FileUtils.fileName(url, topicsDir, TOPIC_PARTITION, "abcd"));
+    fs.createNewFile(path);
+
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    hdfsWriter.recover(TOPIC_PARTITION);
+
+    Map<TopicPartition, Long> committedOffsets = hdfsWriter.getCommittedOffsets();
+
+    assertTrue(committedOffsets.containsKey(TOPIC_PARTITION));
+    long previousOffset = committedOffsets.get(TOPIC_PARTITION);
+    assertEquals(previousOffset, 5L);
+
+    hdfsWriter.close();
+  }
+
+  @Test
+  public void testWriteRecordNonZeroInitailOffset() throws Exception {
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+    hdfsWriter.recover(TOPIC_PARTITION);
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = 3; offset < 10; offset++) {
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, offset);
+      sinkRecords.add(sinkRecord);
+    }
+
+    hdfsWriter.write(sinkRecords);
     hdfsWriter.close();
 
     long[] validOffsets = {2, 5, 8, 9};
     for (int i = 1; i < validOffsets.length; i++) {
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, topicPart, validOffsets[i]));
+      long startOffset = validOffsets[i - 1] + 1;
+      long endOffset = validOffsets[i];
+      Path path = new Path(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, startOffset, endOffset));
       Collection<Object> records = readAvroFile(path);
-      long size = validOffsets[i] - validOffsets[i - 1];
+      long size = endOffset - startOffset + 1;
+      assertEquals(size, records.size());
+      for (Object avroRecord : records) {
+        assertEquals(avroData.fromCopycatData(schema, record), avroRecord);
+      }
+    }
+  }
+
+  @Test
+  public void testRebalance() throws Exception {
+    HdfsWriter hdfsWriter = new HdfsWriter(connectorConfig, context, avroData);
+
+    for (TopicPartition tp: assignment) {
+      hdfsWriter.recover(tp);
+    }
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
+    for (TopicPartition tp: assignment) {
+      for (long offset = 0; offset < 7; offset++) {
+        SinkRecord sinkRecord =
+            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
+        sinkRecords.add(sinkRecord);
+      }
+    }
+    hdfsWriter.write(sinkRecords);
+
+    Set<TopicPartition> oldAssignment = new HashSet<>();
+    for (TopicPartition tp: assignment) {
+      oldAssignment.add(tp);
+    }
+
+    Set<TopicPartition> newAssignment = new HashSet<>();
+    newAssignment.add(TOPIC_PARTITION);
+    newAssignment.add(TOPIC_PARTITION3);
+
+    hdfsWriter.onPartitionsRevoked(assignment);
+
+    hdfsWriter.onPartitionsAssigned(newAssignment);
+    assertEquals(newAssignment, assignment);
+
+    assertEquals(null, hdfsWriter.getRecordWriter(TOPIC_PARTITION2));
+    assertEquals(null, hdfsWriter.getWAL(TOPIC_PARTITION2));
+
+    long[] validOffsetsTopicPartition2 = {5, 6};
+    for (int j = 1; j < validOffsetsTopicPartition2.length; ++j) {
+      long startOffset = validOffsetsTopicPartition2[j - 1] + 1;
+      long endOffset = validOffsetsTopicPartition2[j];
+      Path path = new Path(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION2, startOffset, endOffset));
+      Collection<Object> records = readAvroFile(path);
+      long size = endOffset - startOffset + 1;
       assertEquals(records.size(), size);
-      for (Object avroRecord: records) {
-        assertEquals(avroRecord, AvroData.convertToAvro(record));
+      for (Object avroRecord : records) {
+        assertEquals(avroData.fromCopycatData(schema, record), avroRecord);
       }
     }
 
-    long[] inValidOffsets = {3, 4, 6, 7};
-    for (long offset: inValidOffsets) {
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, topicPart, offset));
-      assertFalse(fs.exists(path));
+    sinkRecords.clear();
+    for (TopicPartition tp: assignment) {
+      for (long offset = 7; offset < 10; offset++) {
+        SinkRecord sinkRecord =
+            new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset);
+        sinkRecords.add(sinkRecord);
+      }
     }
+
+    hdfsWriter.write(sinkRecords);
+    hdfsWriter.close();
+
+    long[] validOffsetsTopicPartition1 = {5, 8, 9};
+    for (int j = 1; j < validOffsetsTopicPartition1.length; ++j) {
+      long startOffset = validOffsetsTopicPartition1[j - 1] + 1;
+      long endOffset = validOffsetsTopicPartition1[j];
+      Path path = new Path(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, startOffset, endOffset));
+      Collection<Object> records = readAvroFile(path);
+      long size = endOffset - startOffset + 1;
+      assertEquals(records.size(), size);
+      for (Object avroRecord : records) {
+        assertEquals(avroData.fromCopycatData(schema, record), avroRecord);
+      }
+    }
+
+    long[] validOffsetsTopicPartition3 = {6, 9};
+    for (int j = 1; j < validOffsetsTopicPartition3.length; ++j) {
+      long startOffset = validOffsetsTopicPartition3[j - 1] + 1;
+      long endOffset = validOffsetsTopicPartition3[j];
+      Path path = new Path(FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION3, startOffset, endOffset));
+      Collection<Object> records = readAvroFile(path);
+      long size = endOffset - startOffset + 1;
+      assertEquals(records.size(), size);
+      for (Object avroRecord : records) {
+        assertEquals(avroData.fromCopycatData(schema, record), avroRecord);
+      }
+    }
+    assignment = oldAssignment;
   }
 }

--- a/src/test/java/io/confluent/copycat/hdfs/WALFileTest.java
+++ b/src/test/java/io/confluent/copycat/hdfs/WALFileTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class WALFileTest extends HdfsSinkConnectorTestBase {
+
+  @Test(timeout = 30000)
+  public void testeAppend() throws Exception {
+    Properties props = createProps();
+    HdfsSinkConnectorConfig connectorConfig = new HdfsSinkConnectorConfig(props);
+
+    String topicsDir = connectorConfig.getString(HdfsSinkConnectorConfig.TOPIC_DIR_CONFIG);
+    String topic = "topic";
+    int partition = 0;
+    TopicPartition topicPart = new TopicPartition(topic, partition);
+
+    Path file = new Path(FileUtils.logFileName(url, topicsDir, topicPart));
+
+    WALFile.Writer writer = WALFile.createWriter(conf, WALFile.Writer.file(file));
+
+    WALEntry key1 = new WALEntry("key1");
+    WALEntry val1 = new WALEntry("val1");
+
+    WALEntry key2 = new WALEntry("key2");
+    WALEntry val2 = new WALEntry("val2");
+
+    writer.append(key1, val1);
+    writer.append(key2, val2);
+    writer.close();
+
+    verify2Values(file);
+
+    writer = WALFile.createWriter(conf, WALFile.Writer.file(file), WALFile.Writer.appendIfExists(true));
+
+    WALEntry key3 = new WALEntry("key3");
+    WALEntry val3 = new WALEntry("val3");
+
+    WALEntry key4 = new WALEntry("key4");
+    WALEntry val4 = new WALEntry("val4");
+
+    writer.append(key3, val3);
+    writer.append(key4, val4);
+    writer.hsync();
+    writer.close();
+
+    verifyAll4Values(file);
+
+    fs.deleteOnExit(file);
+  }
+
+  private void verify2Values(Path file) throws IOException {
+    WALEntry key1 = new WALEntry("key1");
+    WALEntry val1 = new WALEntry("val1");
+
+    WALEntry key2 = new WALEntry("key2");
+    WALEntry val2 = new WALEntry("val2");
+
+    WALFile.Reader reader = new WALFile.Reader(conf, WALFile.Reader.file(file));
+
+    assertEquals(key1.getFilename(), ((WALEntry) reader.next((Object) null)).getFilename());
+    assertEquals(val1.getFilename(), ((WALEntry) reader.getCurrentValue((Object) null)).getFilename());
+    assertEquals(key2.getFilename(), ((WALEntry) reader.next((Object) null)).getFilename());
+    assertEquals(val2.getFilename(), ((WALEntry) reader.getCurrentValue((Object) null)).getFilename());
+    assertNull(reader.next((Object) null));
+    reader.close();
+  }
+
+  private void verifyAll4Values(Path file) throws IOException {
+    WALEntry key1 = new WALEntry("key1");
+    WALEntry val1 = new WALEntry("val1");
+
+    WALEntry key2 = new WALEntry("key2");
+    WALEntry val2 = new WALEntry("val2");
+
+    WALEntry key3 = new WALEntry("key3");
+    WALEntry val3 = new WALEntry("val3");
+
+    WALEntry key4 = new WALEntry("key4");
+    WALEntry val4 = new WALEntry("val4");
+
+    WALFile.Reader reader = new WALFile.Reader(conf, WALFile.Reader.file(file));
+    assertEquals(key1.getFilename(), ((WALEntry) reader.next((Object) null)).getFilename());
+    assertEquals(val1.getFilename(), ((WALEntry) reader.getCurrentValue((Object) null)).getFilename());
+    assertEquals(key2.getFilename(), ((WALEntry) reader.next((Object) null)).getFilename());
+    assertEquals(val2.getFilename(), ((WALEntry) reader.getCurrentValue((Object) null)).getFilename());
+
+    assertEquals(key3.getFilename(), ((WALEntry) reader.next((Object) null)).getFilename());
+    assertEquals(val3.getFilename(), ((WALEntry) reader.getCurrentValue((Object) null)).getFilename());
+    assertEquals(key4.getFilename(), ((WALEntry) reader.next((Object) null)).getFilename());
+    assertEquals(val4.getFilename(), ((WALEntry) reader.getCurrentValue((Object) null)).getFilename());
+    assertNull(reader.next((Object) null));
+    reader.close();
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/WALTest.java
+++ b/src/test/java/io/confluent/copycat/hdfs/WALTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.copycat.errors.CopycatException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WALTest extends HdfsSinkConnectorTestBase {
+
+  private boolean closed;
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testWALMultiClient() throws Exception {
+    fs.delete(new Path(FileUtils.directoryName(url, topicsDir, TOPIC_PARTITION)), true);
+
+    Class<? extends Storage> storageClass = (Class<? extends Storage>)
+        Class.forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
+    Storage storage = StorageFactory.createStorage(storageClass, conf, url);
+
+    final WAL wal1 = storage.wal(topicsDir, TOPIC_PARTITION);
+    final WAL wal2 = storage.wal(topicsDir, TOPIC_PARTITION);
+
+    final String tempfile = FileUtils.tempFileName(url, topicsDir, TOPIC_PARTITION);
+    final String commitedFile = FileUtils.committedFileName(url, topicsDir, TOPIC_PARTITION, 0, 10);
+
+    fs.createNewFile(new Path(tempfile));
+
+    wal1.acquireLease();
+    wal1.append(tempfile, commitedFile);
+
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          // holding the lease for awhile
+          Thread.sleep(3000);
+          closed = true;
+          wal1.close();
+        } catch (CopycatException | InterruptedException e) {
+          // Ignored
+        }
+      }
+    });
+    thread.start();
+
+    wal2.acquireLease();
+    assertTrue(closed);
+    wal2.apply();
+    wal2.close();
+
+    assertTrue(fs.exists(new Path(commitedFile)));
+    assertFalse(fs.exists(new Path(tempfile)));
+    storage.close();
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/utils/Data.java
+++ b/src/test/java/io/confluent/copycat/hdfs/utils/Data.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs.utils;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Data {
+  private static final Map<String, List<Object>> data = new HashMap<>();
+
+  public static Map<String, List<Object>> getData() {
+    return data;
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/utils/MemoryRecordWriter.java
+++ b/src/test/java/io/confluent/copycat/hdfs/utils/MemoryRecordWriter.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.copycat.hdfs.utils;
+
+import org.apache.kafka.copycat.sink.SinkRecord;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.copycat.hdfs.RecordWriter;
+
+public class MemoryRecordWriter implements RecordWriter<Long, SinkRecord> {
+  private String filename;
+  private static final Map<String, List<Object>> data = Data.getData();
+  private Failure failure = Failure.noFailure;
+
+  public enum Failure {
+    noFailure,
+    writeFailure,
+    closeFailure
+  }
+
+  public MemoryRecordWriter(String filename) {
+    this.filename = filename;
+  }
+
+  public void write(Long key, SinkRecord record) throws IOException {
+    if (failure == Failure.writeFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("write failed.");
+    }
+    data.get(filename).add(record);
+
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (failure == Failure.closeFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("close failed.");
+    }
+  }
+
+  public void setFailure(Failure failure) {
+    this.failure = failure;
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/utils/MemoryRecordWriterProvider.java
+++ b/src/test/java/io/confluent/copycat/hdfs/utils/MemoryRecordWriterProvider.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.kafka.copycat.sink.SinkRecord;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.copycat.avro.AvroData;
+import io.confluent.copycat.hdfs.RecordWriter;
+import io.confluent.copycat.hdfs.RecordWriterProvider;
+
+public class MemoryRecordWriterProvider implements RecordWriterProvider {
+
+  @Override
+  public RecordWriter<Long, SinkRecord> getRecordWriter(Configuration conf, final String fileName,
+                                                        SinkRecord record, final AvroData avroData)
+      throws IOException {
+
+    final Map<String, List<Object>> data = Data.getData();
+
+    if (!data.containsKey(fileName)) {
+      data.put(fileName, new LinkedList<>());
+    }
+
+    return new MemoryRecordWriter(fileName);
+  }
+
+
+}

--- a/src/test/java/io/confluent/copycat/hdfs/utils/MemoryStorage.java
+++ b/src/test/java/io/confluent/copycat/hdfs/utils/MemoryStorage.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.copycat.hdfs.Storage;
+import io.confluent.copycat.hdfs.WAL;
+
+public class MemoryStorage implements Storage {
+
+  private static final Map<String, List<Object>> data = Data.getData();
+  private Configuration conf;
+  private String url;
+  private Failure failure = Failure.noFailure;
+
+  public enum Failure {
+    noFailure,
+    listStatusFailure,
+    appendFailure,
+    mkdirsFailure,
+    existsFailure,
+    deleteFailure,
+    commitFailure,
+    closeFailure
+  }
+
+  public MemoryStorage(Configuration conf,  String url) {
+    this.conf = conf;
+    this.url = url;
+  }
+
+  @Override
+  public FileStatus[] listStatus(String path, PathFilter filter) throws IOException {
+    if (failure == Failure.listStatusFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("listStatus failed.");
+    }
+    List<FileStatus> result = new ArrayList<>();
+    for (String key: data.keySet()) {
+      if (key.startsWith(path) && filter.accept(new Path(key))) {
+          FileStatus status = new FileStatus(data.get(key).size(), false, 1, 0, 0, 0, null, null, null, new Path(key));
+          result.add(status);
+      }
+    }
+    return result.toArray(new FileStatus[result.size()]);
+  }
+
+  @Override
+  public void append(String filename, Object object) throws IOException {
+    if (failure == Failure.appendFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("append failed.");
+    }
+    if (!data.containsKey(filename)) {
+      data.put(filename, new LinkedList<>());
+    }
+    data.get(filename).add(object);
+  }
+
+  @Override
+  public boolean mkdirs(String filename) throws IOException {
+    if (failure == Failure.mkdirsFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("mkdirs failed.");
+    }
+    return true;
+  }
+
+  @Override
+  public boolean exists(String filename) throws IOException {
+    if (failure == Failure.existsFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("exists failed.");
+    }
+    return data.containsKey(filename);
+  }
+
+  @Override
+  public void delete(String filename) throws IOException {
+    if (failure == Failure.deleteFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("delete failed.");
+    }
+    if (data.containsKey(filename)) {
+      data.get(filename).clear();
+      data.remove(filename);
+    }
+  }
+
+  @Override
+  public void commit(String tempFile, String committedFile) throws IOException {
+    if (failure == Failure.commitFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("commit failed.");
+    }
+    if (!data.containsKey(committedFile)) {
+      List<Object> entryList = data.get(tempFile);
+      data.put(committedFile, entryList);
+      data.remove(tempFile);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (failure == Failure.closeFailure) {
+      failure = Failure.noFailure;
+      throw new IOException("close failed.");
+    }
+    data.clear();
+  }
+
+  @Override
+  public WAL wal(String topicsDir, TopicPartition topicPart) {
+    return new MemoryWAL(topicsDir, topicPart, this);
+  }
+
+  @Override
+  public Configuration conf() {
+    return conf;
+  }
+
+  @Override
+  public String url() {
+    return url;
+  }
+
+  public void setFailure(Failure failure) {
+    this.failure = failure;
+  }
+}

--- a/src/test/java/io/confluent/copycat/hdfs/utils/MemoryWAL.java
+++ b/src/test/java/io/confluent/copycat/hdfs/utils/MemoryWAL.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.copycat.hdfs.utils;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.copycat.errors.CopycatException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.copycat.hdfs.FileUtils;
+import io.confluent.copycat.hdfs.Storage;
+import io.confluent.copycat.hdfs.WAL;
+
+public class MemoryWAL implements WAL {
+
+  private String logFile;
+  private Storage storage;
+  private static Map<String, List<Object>> data = Data.getData();
+
+  public MemoryWAL(String topicsDir, TopicPartition topicPart, Storage storage)
+      throws CopycatException {
+    this.storage = storage;
+    String url = storage.url();
+    logFile = FileUtils.logFileName(url, topicsDir, topicPart);
+  }
+
+
+  @Override
+  public void acquireLease() throws CopycatException {
+
+  }
+
+  @Override
+  public void append(String tempFile, String committedFile) throws CopycatException {
+    try {
+      LogEntry entry = new LogEntry(tempFile, committedFile);
+      storage.append(logFile, entry);
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  @Override
+  public void apply() throws CopycatException {
+    try {
+      if (data.containsKey(logFile)) {
+        List<Object> entryList = data.get(logFile);
+        for (Object entry : entryList) {
+          LogEntry logEntry = (LogEntry) entry;
+          storage.commit(logEntry.key(), logEntry.value());
+        }
+      }
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  @Override
+  public void truncate() throws CopycatException {
+    try {
+      storage.commit(logFile, logFile + ".1");
+      storage.delete(logFile);
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  @Override
+  public void close() throws CopycatException {
+    try {
+      storage.close();
+    } catch (IOException e) {
+      throw new CopycatException(e);
+    }
+  }
+
+  @Override
+  public String getLogFile() {
+    return logFile;
+  }
+
+  private static class LogEntry {
+    private String key;
+    private String value;
+
+    public LogEntry(String key, String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String key() {
+      return key;
+    }
+
+    public String value() {
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
@ewencp  Can you review it and provide some feedback? Thanks!
This PR adds the following functionality:
1. Time based file rotate using ScheduledExecutorService. 
2. WAL implementation to ensure exactly once delivery in case of failure and zombie writes.

TODO:
1. Replace SequenceFile class with a customized format. This PR uses the SequenceFile  implementation in hadoop trunk. 
2. WAL truncation. Currently, to make sure that we don't commit a file in WAL with a certain starting offset if there is already a committed file with the same start offset to ensure that data is not written to HDFS more than once.  This operation is relatively expensive if there are lots of committed files under a topic partition directory.  Truncating the WAL can reduce the number of such operations.  
3. Create WAL factory class to enable different implementation of WAL and some refactoring of WAL api. 
4. Currently, HBase uses disruptor to perform sync to HDFS asynchronously. And we call fsync appending each entry to WAL? Given that our frequency in writing to WAL is much smaller than HBase, do you think it is worth exploring this option? 